### PR TITLE
remove meaningless parameters

### DIFF
--- a/src/graph_builder/graph/operators/average_pooling_2d.py
+++ b/src/graph_builder/graph/operators/average_pooling_2d.py
@@ -16,11 +16,14 @@ class AveragePooling2D(Operator):
 
     def __init__(self, name: str, parameters: Dict[str, object]):
         """
-        parameters: {out_size: int, ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int]}
+        parameters: {ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int]}
         :param name: 
         :param parameters: 
         :param weights: 
         """
+        assert "ksize" in parameters
+        assert "stride" in parameters
+        assert "padding" in parameters
         super().__init__(name, parameters)
 
     def __call__(self, x: Variable):

--- a/src/graph_builder/graph/operators/axiswise_bias.py
+++ b/src/graph_builder/graph/operators/axiswise_bias.py
@@ -15,6 +15,12 @@ class AxiswiseBias(Operator):
                   A.HaveWeights}
 
     def __init__(self, name: str, parameters: Dict[str, object]):
+        """
+        parameters: {axis: A.Axis}
+        :param name: 
+        :param parameters: 
+        """
+        assert "axis" in parameters
         assert isinstance(parameters["axis"], A.Axis)
         super().__init__(name, parameters)
 

--- a/src/graph_builder/graph/operators/axiswise_scale.py
+++ b/src/graph_builder/graph/operators/axiswise_scale.py
@@ -15,6 +15,12 @@ class AxiswiseScale(Operator):
                   A.HaveWeights}
 
     def __init__(self, name: str, parameters: Dict[str, object]):
+        """
+        parameters: {axis: A.Axis}
+        :param name: 
+        :param parameters: 
+        """
+        assert "axis" in parameters
         assert isinstance(parameters["axis"], A.Axis)
         super().__init__(name, parameters)
 

--- a/src/graph_builder/graph/operators/concat.py
+++ b/src/graph_builder/graph/operators/concat.py
@@ -14,11 +14,9 @@ class Concat(Operator):
 
     def __init__(self, name: str, parameters: Dict[str, object]):
         """
-        parameters: {axis: int, n_inputs: int}
-        n_inputs: 入力変数の数
+        parameters: {axis: int}
         :param name: 
         :param parameters: 
-        :param weights: 
         """
         assert "axis" in parameters
         assert isinstance(parameters["axis"], A.Axis)

--- a/src/graph_builder/graph/operators/convolution2d.py
+++ b/src/graph_builder/graph/operators/convolution2d.py
@@ -16,10 +16,9 @@ class Convolution2D(Operator):
     def __init__(self, name: str, parameters: Dict[str, object]):
         """
         weights["W"]: (kh, kw, in_size, out_size)
-        parameters: {in_size: int, out_size: int, ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
+        parameters: {ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
         :param name: 
         :param parameters: 
-        :param weights: 
         """
         assert "ksize" in parameters
         assert "stride" in parameters

--- a/src/graph_builder/graph/operators/deconvolution2d.py
+++ b/src/graph_builder/graph/operators/deconvolution2d.py
@@ -13,13 +13,12 @@ class Deconvolution2D(Operator):
                   A.PostAxiswise,
                   A.HaveWeights}
 
-    def __init__(self, name: str, parameters: Dict[str, object] = None):
+    def __init__(self, name: str, parameters: Dict[str, object]):
         """
         weights["W"]: (kh, kw, in_size, out_size)
-        parameters: {in_size: int, out_size: int, ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
+        parameters: {ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
         :param name: 
         :param parameters: 
-        :param weights: 
         """
         assert "ksize" in parameters
         assert "stride" in parameters

--- a/src/graph_builder/graph/operators/elementwise_sum.py
+++ b/src/graph_builder/graph/operators/elementwise_sum.py
@@ -14,8 +14,6 @@ class ElementwiseSum(Operator):
 
     def __init__(self, name: str, parameters: Dict[str, object] = None):
         """
-        parameters: {n_inputs: int}
-        n_inputs: 入力変数の数
         :param name: 
         :param parameters: 
         """

--- a/src/graph_builder/graph/operators/max_pooling_2d.py
+++ b/src/graph_builder/graph/operators/max_pooling_2d.py
@@ -13,13 +13,12 @@ class MaxPooling2D(Operator):
     attributes = {A.PostElementwise,
                   A.PostAxiswise}
 
-    def __init__(self, name: str, parameters: Dict[str, object] = None):
+    def __init__(self, name: str, parameters: Dict[str, object]):
         """
         weights["W"]: (kh, kw, in_size, out_size)
-        parameters: {in_size: int, out_size: int, ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
+        parameters: {ksize: Tuple[int, int], stride: Tuple[int, int], pad: Tuple[int, int], cover_all: Boolean=False}
         :param name: 
         :param parameters: 
-        :param weights: 
         """
         assert "ksize" in parameters
         assert "stride" in parameters

--- a/src/graph_builder/graph/operators/relu.py
+++ b/src/graph_builder/graph/operators/relu.py
@@ -16,6 +16,10 @@ class Relu(Operator):
                   A.Inplace}
 
     def __init__(self, name: str, parameters: Dict[str, object] = None):
+        """
+        :param name: 
+        :param parameters: 
+        """
         super().__init__(name, parameters)
 
     def __call__(self, x: Variable):

--- a/src/graph_builder/graph/operators/reshape.py
+++ b/src/graph_builder/graph/operators/reshape.py
@@ -13,14 +13,14 @@ class Reshape(Operator):
                   A.PostAxiswise,
                   A.Inplace}
 
-    def __init__(self, name: str, parameters: Dict[str, object] = None):
+    def __init__(self, name: str, parameters: Dict[str, object]):
         """
-        parameters: {out_shape: Tuple}
+        parameters: {out_shape: Tuple, out_order: VA.Order}
         :param name: 
         :param parameters: 
-        :param weights: 
         """
         assert "out_shape" in parameters
+        assert "out_order" in parameters
         super().__init__(name, parameters)
 
     def __call__(self, x: Variable):

--- a/src/graph_builder/graph/operators/sigmoid.py
+++ b/src/graph_builder/graph/operators/sigmoid.py
@@ -15,6 +15,10 @@ class Sigmoid(Operator):
                   A.Inplace}
 
     def __init__(self, name: str, parameters: Dict[str, object] = None):
+        """
+        :param name: 
+        :param parameters: 
+        """
         super().__init__(name, parameters)
 
     def __call__(self, x: Variable):


### PR DESCRIPTION
convの `{"in_size": int}` など、データ依存なものを削除