### PR TITLE
add softmax and related optimize_rule

### DIFF
--- a/src/graph_builder/frontend/general_optimizer.py
+++ b/src/graph_builder/frontend/general_optimizer.py
@@ -1,5 +1,6 @@
 from graph_builder.frontend.optimize_rules.compose_axiswise_operation import ComposeAxiswiseOperation
 from graph_builder.frontend.optimize_rules.compose_elementwise_operation import ComposeElementwiseOperation
+from graph_builder.frontend.optimize_rules.remove_last_softmax import RemoveLastSoftmax
 from graph_builder.optimizer import Optimizer
 
 
@@ -9,3 +10,4 @@ class GeneralOptimizer(Optimizer):
 
         self.register_rule(ComposeAxiswiseOperation())
         self.register_rule(ComposeElementwiseOperation())
+        self.register_rule(RemoveLastSoftmax())

--- a/src/graph_builder/frontend/optimize_rules/remove_last_softmax.py
+++ b/src/graph_builder/frontend/optimize_rules/remove_last_softmax.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from graph_builder.graph import Operator, operators as O, Variable
+from graph_builder.optimizer import OptimizeRule
+from graph_builder.util import flags
+
+
+class RemoveLastSoftmax(OptimizeRule):
+    """
+    最終出力を作る関数がSoftmaxなら、これを削除する
+    """
+
+    def __call__(self, graph: Operator):
+        if not flags.optimize.REMOVE_LAST_SOFTMAX:
+            return graph, False
+
+        flag_changed = False
+        var_queue: List[Variable] = list(graph.outputs.values())
+
+        while len(var_queue) > 0:
+            v = var_queue.pop(0)
+
+            if isinstance(v.output_from, O.Compose):
+                composed = v.output_from  # type: O.Compose
+                var_queue.extend(list(composed.outputs_alias))
+                continue
+
+            elif isinstance(v.output_from, O.Softmax):
+                softmax = v.output_from  # type: O.Softmax
+                softmax.remove_self()
+                flag_changed = True
+
+        return graph, flag_changed

--- a/src/graph_builder/graph/operators/__init__.py
+++ b/src/graph_builder/graph/operators/__init__.py
@@ -11,3 +11,4 @@ from graph_builder.graph.operators.max_pooling_2d import MaxPooling2D
 from graph_builder.graph.operators.relu import Relu
 from graph_builder.graph.operators.reshape import Reshape
 from graph_builder.graph.operators.sigmoid import Sigmoid
+from graph_builder.graph.operators.softmax import Softmax

--- a/src/graph_builder/graph/operators/softmax.py
+++ b/src/graph_builder/graph/operators/softmax.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+from graph_builder.graph.graph import Operator, Variable
+from graph_builder.graph.operators import attributes as A
+
+
+class Softmax(Operator):
+    """
+    Softmaxレイヤー
+    """
+    attributes = {A.Inplace}
+
+    def __init__(self, name: str, parameters: Dict[str, object] = None):
+        """
+        :param name: 
+        :param parameters: 
+        """
+        super().__init__(name, parameters)
+
+    def __call__(self, x: Variable):
+        y = Variable(x.shape, x.axis_order)
+        self.append_input("x", x)
+        self.append_output("y", y)
+        return y,
+
+    def remove_self(self):
+        """
+        最適化のため、自分を削除する
+        """
+        x = self.inputs["x"]
+        y = self.outputs["y"]
+
+        self.remove_output(y)
+        x.output_from.replace_output(x, y)

--- a/src/graph_builder/util/flags/optimize.py
+++ b/src/graph_builder/util/flags/optimize.py
@@ -1,6 +1,7 @@
 MINIMIZE_VARIABLE_ALLOCATION = True
 CONCAT_ELEMENTWISE_OPERATION = True
 CONCAT_CHANNELWISE_OPERATION = True
+REMOVE_LAST_SOFTMAX = False
 
 # When this flag is true, int and float value of meta_buffer is embedded kernel source code as literal.
 EMBED_METABUFFER_VALUE = False


### PR DESCRIPTION
Softmax削除の最適化（ `RemoveLastSoftmax` ) はフラグ `flags.optimization.REMOVE_LAST_SOFTMAX` によりデフォルトではオフになっています。