### PR TITLE
Support hierarchical optimize rule

### DIFF
--- a/src/graph_builder/backend/webgpu/generator.py
+++ b/src/graph_builder/backend/webgpu/generator.py
@@ -28,7 +28,7 @@ from graph_builder.backend.webgpu.kernels.relu import relu
 from graph_builder.backend.webgpu.kernels.sgemm import sgemm
 from graph_builder.backend.webgpu.operators.im2col import Im2Col
 from graph_builder.backend.webgpu.operators.sgemm import Sgemm
-from graph_builder.backend.webgpu.webgpu_optimizer import WebGPUOptimizer
+from graph_builder.backend.webgpu.optimizers.webgpu_optimizer import WebGPUOptimizer
 from graph_builder.graph.operator import Operator
 from graph_builder.graph.operators.attributes.optimize_hint import ElementwiseOperationComposed
 from graph_builder.graph.operators.average_pooling_2d import AveragePooling2D

--- a/src/graph_builder/backend/webgpu/optimizers/webgpu_conv_optimizer.py
+++ b/src/graph_builder/backend/webgpu/optimizers/webgpu_conv_optimizer.py
@@ -5,11 +5,11 @@ from graph_builder.backend.webgpu.optimize_rules.sgemm_bias_relu import SgemmBia
 from graph_builder.optimizer.optimizer import Optimizer
 
 
-class WebGPUOptimizer(Optimizer):
+class WebGPUConvOptimizer(Optimizer):
     def __init__(self):
-        super(WebGPUOptimizer, self).__init__()
+        super(WebGPUConvOptimizer, self).__init__()
 
-        self.register_rule(ConvScale())
-        self.register_rule(ReplaceConvolutionByIm2Col())
-        self.register_rule(AdjustConvWeightDataOrder())
-        self.register_rule(SgemmBiasRelu())
+        self.register(ConvScale())
+        self.register(ReplaceConvolutionByIm2Col())
+        self.register(AdjustConvWeightDataOrder())
+        self.register(SgemmBiasRelu())

--- a/src/graph_builder/backend/webgpu/optimizers/webgpu_optimizer.py
+++ b/src/graph_builder/backend/webgpu/optimizers/webgpu_optimizer.py
@@ -1,0 +1,9 @@
+from graph_builder.backend.webgpu.optimizers.webgpu_conv_optimizer import WebGPUConvOptimizer
+from graph_builder.optimizer.optimizer import Optimizer
+
+
+class WebGPUOptimizer(Optimizer):
+    def __init__(self):
+        super(WebGPUOptimizer, self).__init__()
+
+        self.register(WebGPUConvOptimizer())

--- a/src/graph_builder/frontend/general_optimizer.py
+++ b/src/graph_builder/frontend/general_optimizer.py
@@ -1,15 +1,13 @@
-from graph_builder.frontend.optimize_rules.compose_axiswise_operation import ComposeAxiswiseOperation
-from graph_builder.frontend.optimize_rules.compose_elementwise_operation import ComposeElementwiseOperation
+from graph_builder.frontend.optimize_rules.affine_concat import AffineConcat
 from graph_builder.frontend.optimize_rules.remove_last_softmax import RemoveLastSoftmax
 from graph_builder.optimizer.optimizer import Optimizer
-from graph_builder.frontend.optimize_rules.affine_concat import AffineConcat
 
 
 class GeneralOptimizer(Optimizer):
     def __init__(self):
         super(GeneralOptimizer, self).__init__()
 
-        # self.register_rule(ComposeAxiswiseOperation())
-        # self.register_rule(ComposeElementwiseOperation())
-        self.register_rule(RemoveLastSoftmax())
-        self.register_rule(AffineConcat())
+        # self.register(ComposeAxiswiseOperation())
+        # self.register(ComposeElementwiseOperation())
+        self.register(RemoveLastSoftmax())
+        self.register(AffineConcat())

--- a/src/graph_builder/optimizer/optimizer.py
+++ b/src/graph_builder/optimizer/optimizer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from graph_builder.graph.operator import Operator
 from graph_builder.optimizer import util
@@ -6,26 +6,35 @@ from graph_builder.optimizer.optimize_rule import OptimizeRule
 from graph_builder.util import flags
 
 
-class Optimizer:
+class Optimizer(OptimizeRule):
     rules: List[OptimizeRule]
 
     def __init__(self):
         self.rules = []
 
-    def optimize(self, graph: Operator):
+    def optimize(self, graph: Operator) -> Operator:
+        return self(graph)[0]
+
+    def __call__(self, graph: Operator) -> Tuple[Operator, bool]:
 
         flag_retry = True
+        flag_totally_changed = False
+
         while flag_retry:
             flag_retry = False
+
             for rule in self.rules:
                 graph, flag_changed = rule(graph)
                 flag_retry |= flag_changed
+
                 if flags.DEBUG:
                     print(f"[Optimizer] optimize rule={rule} changed={flag_changed}")
                     util.dump(graph)
                     print()
 
-        return graph
+            flag_totally_changed |= flag_retry
 
-    def register_rule(self, rule: OptimizeRule):
+        return graph, flag_totally_changed
+
+    def register(self, rule: OptimizeRule):
         self.rules.append(rule)


### PR DESCRIPTION
Optimizerのルールとして、Optimizer自身を追加できるように実装。
これまでとのインターフェースの違いは `register_rule` が `register` に変更されたことのみ。

```python
optimizer1 = Optimizer1()
optimizer2 = Optimizer2()

optimizer2.register(rule2_1)
optimizer2.register(rule2_2)


optimizer1.register(optimize_rule1_1)
optimizer1.register(optimizer2)
optimizer1.register(optimize_rule2_1)

optimizer1.optimize(graph) # rule1_1 => rule2_1 => rule2_2 => rule1_2 の順
```

これにより、順序依存な複数のルールをまとめて１つのルールのように扱うことができるようになる