### PR TITLE
add backend name interface

### DIFF
--- a/src/descriptor_runner/descriptor_runner/descriptor_runner.ts
+++ b/src/descriptor_runner/descriptor_runner/descriptor_runner.ts
@@ -5,6 +5,8 @@ namespace WebDNN {
      * `DescriptorRunner` executes computation based on `GraphDescriptor`.
      */
     export interface DescriptorRunner {
+        backend: string;
+
         /**
          * Fetch descriptor from specified directory.
          * @param directory directory where descriptor is contained.


### PR DESCRIPTION
`DescriptorRunner` にbackend名を取れるフィールドを追加（継承先ですでに用意されているので本質的な変更はなし）