### PR TITLE
Add concat operator for webgpu and wasm backends

### DIFF
--- a/src/graph_transpiler/webdnn/backend/webassembly/generator.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/generator.py
@@ -18,6 +18,7 @@ from webdnn.backend.webassembly.kernels.average_pooling_2d import average_poolin
 from webdnn.backend.webassembly.kernels.axiswise_bias import axiswise_bias
 from webdnn.backend.webassembly.kernels.axiswise_scale import axiswise_scale
 from webdnn.backend.webassembly.kernels.col2im import col2im
+from webdnn.backend.webassembly.kernels.concat import concat
 from webdnn.backend.webassembly.kernels.elementwise_sum import elementwise_sum
 from webdnn.backend.webassembly.kernels.elu import elu
 from webdnn.backend.webassembly.kernels.flatten import flatten
@@ -41,6 +42,7 @@ from webdnn.graph.operator import Operator
 from webdnn.graph.operators.average_pooling_2d import AveragePooling2D
 from webdnn.graph.operators.axiswise_bias import AxiswiseBias
 from webdnn.graph.operators.axiswise_scale import AxiswiseScale
+from webdnn.graph.operators.concat import Concat
 from webdnn.graph.operators.elementwise_sum import ElementwiseSum
 from webdnn.graph.operators.elu import Elu
 from webdnn.graph.operators.flatten import Flatten
@@ -205,6 +207,9 @@ def generate_kernels(graph: Graph, constants_layout: MemoryLayout, variables_lay
 
         elif isinstance(op, ScalarAffine):
             kernels += scalar_affine(op, constants_layout, variables_layout)
+
+        elif isinstance(op, Concat):
+            kernels += concat(op, constants_layout, variables_layout)
 
         elif isinstance(op, Operator):
             if "custom_kernel" in op.parameters:

--- a/src/graph_transpiler/webdnn/backend/webassembly/kernels/concat.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/kernels/concat.py
@@ -1,0 +1,76 @@
+from typing import List
+
+import numpy as np
+
+from webdnn.backend.webassembly.kernel import Kernel
+from webdnn.backend.webassembly.kernels import util
+from webdnn.backend.webassembly.meta_buffer_injector import MetaBufferInjector
+from webdnn.backend.webgpu.allocator import MemoryLayout
+from webdnn.graph.operators.concat import Concat
+
+template = """
+void %%FUNC_NAME%%(const int * %%META_NAME%%)
+{
+    float *y = data_buffer + %%META_LOAD(concat_y_offset)%%;
+    const int N = %%META_LOAD(concat_N)%%;
+    const int *x_offsets = &(%%META_LOAD(concat_x_offsets)%%);
+    const int *x_sizes = &(%%META_LOAD(concat_x_sizes)%%);
+
+    int n = 0;
+    int x_offset = 0;
+    int y_offset = 0;
+    const float *xn = data_buffer + x_offsets[n];
+    int size = x_sizes[n];
+    
+    while (n < N) {
+        if (x_offset >= size) {
+            x_offset -= size;
+            n++;
+            xn = data_buffer + x_offsets[n];
+            size = x_sizes[n];
+            continue;
+        }
+            
+        y[y_offset] = xn[x_offset];
+        
+        x_offset++;
+        y_offset++;
+    }
+}
+"""
+
+
+# noinspection PyUnusedLocal
+def concat(op: Concat,
+           constants_layout: MemoryLayout,
+           variables_layout: MemoryLayout,
+           metabuffer_injector: MetaBufferInjector = None) -> List[Kernel]:
+    xs = [variables_layout[op.inputs[f"x{str(i)}"]] for i in range(len(op.inputs))]
+    y = variables_layout[op.outputs["y"]]
+    axis = op.axis
+
+    assert y.variable.order.axes[0] == axis, "WebGPU backend currently supports only major-axis concat."
+    for x in xs:
+        assert x.variable.shape[1:] == y.variable.shape[1:]
+
+    if metabuffer_injector is None:
+        metabuffer_injector = MetaBufferInjector()
+
+    metabuffer_injector.register({
+        "concat_y_offset": y.offset,
+        "concat_N": len(xs),
+        "concat_x_offsets": np.array([x.offset for x in xs], dtype=np.int32).tobytes(),
+        "concat_x_sizes": np.array([x.size for x in xs], dtype=np.int32).tobytes(),
+    })
+
+    source = metabuffer_injector.inject(template)
+    func_name = util.add_canonical_suffix("concat", source)
+    source = source.replace("%%FUNC_NAME%%", func_name)
+
+    kernel = Kernel(
+        {func_name: source},
+        func_name,
+        metabuffer_injector.generate_buffer()
+    )
+
+    return [kernel]

--- a/src/graph_transpiler/webdnn/backend/webgpu/generator.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/generator.py
@@ -18,6 +18,7 @@ from webdnn.backend.webgpu.kernels.average_pooling_2d import average_pooling_2d
 from webdnn.backend.webgpu.kernels.axiswise_bias import axiswise_bias
 from webdnn.backend.webgpu.kernels.axiswise_scale import axiswise_scale
 from webdnn.backend.webgpu.kernels.col2im import col2im
+from webdnn.backend.webgpu.kernels.concat import concat
 from webdnn.backend.webgpu.kernels.elementwise_sum import elementwise_sum
 from webdnn.backend.webgpu.kernels.elu import elu
 from webdnn.backend.webgpu.kernels.flatten import flatten
@@ -38,6 +39,7 @@ from webdnn.graph.graph import Graph
 from webdnn.graph.operators.average_pooling_2d import AveragePooling2D
 from webdnn.graph.operators.axiswise_bias import AxiswiseBias
 from webdnn.graph.operators.axiswise_scale import AxiswiseScale
+from webdnn.graph.operators.concat import Concat
 from webdnn.graph.operators.elementwise_sum import ElementwiseSum
 from webdnn.graph.operators.elu import Elu
 from webdnn.graph.operators.flatten import Flatten
@@ -169,6 +171,9 @@ def generate_kernels(graph: Graph, constants_layout: MemoryLayout, variables_lay
 
         elif isinstance(op, ScalarAffine):
             kernels += scalar_affine(op, constants_layout, variables_layout)
+
+        elif isinstance(op, Concat):
+            kernels += concat(op, constants_layout, variables_layout)
 
         else:
             raise NotImplementedError(f"{op} is Unknown for WebGPUDescriptorGenerator")

--- a/src/graph_transpiler/webdnn/backend/webgpu/kernels/concat.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/kernels/concat.py
@@ -1,0 +1,81 @@
+from typing import List
+
+import numpy as np
+
+from webdnn.backend.webgpu.allocator import MemoryLayout
+from webdnn.backend.webgpu.injectors.kernel_name_injector import KernelNameInjector
+from webdnn.backend.webgpu.injectors.meta_injector import MetaInjector
+from webdnn.backend.webgpu.kernel import GPUSize, Kernel
+from webdnn.graph.operators.concat import Concat
+
+template = """
+kernel void %%FUNC_NAME%%(const device float *weight_buffer[[buffer(0)]],
+                          device float *data_buffer[[buffer(1)]],
+                          const device int * %%META_NAME%% [[buffer(2)]],
+                          uint index[[thread_position_in_grid]],
+                          uint num_threads[[threads_per_grid]])
+{
+    device float *y = data_buffer + %%META_LOAD(concat_y_offset)%%;
+    const int N = %%META_LOAD(concat_N)%%;
+    const device int *x_offsets = &(%%META_LOAD(concat_x_offsets)%%);
+    const device int *x_sizes = &(%%META_LOAD(concat_x_sizes)%%);
+
+    int n = 0;
+    int x_offset = index;
+    int y_offset = index;
+    device float *xn = data_buffer + x_offsets[n];
+    int size = x_sizes[n];
+    
+    while (n < N) {
+        if (x_offset >= size) {
+            x_offset -= size;
+            n++;
+            xn = data_buffer + x_offsets[n];
+            size = x_sizes[n];
+            continue;
+        }
+            
+        y[y_offset] = xn[x_offset];
+        
+        x_offset += num_threads;
+        y_offset += num_threads;
+    }
+}
+"""
+
+
+# noinspection PyUnusedLocal
+def concat(op: Concat,
+           constants_layout: MemoryLayout,
+           variables_layout: MemoryLayout) -> List[Kernel]:
+    xs = [variables_layout[op.inputs[f"x{str(i)}"]] for i in range(len(op.inputs))]
+    y = variables_layout[op.outputs["y"]]
+    axis = op.axis
+
+    assert y.variable.order.axes[0] == axis, "WebGPU backend currently supports only major-axis concat."
+    for x in xs:
+        assert x.variable.shape[1:] == y.variable.shape[1:]
+
+    meta_injector = MetaInjector()
+    meta_injector.register({
+        "concat_y_offset": y.offset,
+        "concat_N": len(xs),
+        "concat_x_offsets": np.array([x.offset for x in xs], dtype=np.int32).tobytes(),
+        "concat_x_sizes": np.array([x.size for x in xs], dtype=np.int32).tobytes(),
+    })
+
+    name_injector = KernelNameInjector(op)
+
+    source = template
+    source = meta_injector.inject(source)
+    source = name_injector.inject(source)
+
+    kernel = Kernel(
+        {name_injector.name: source},
+        name_injector.name,
+        GPUSize(8, 1, 1),
+        GPUSize(1024, 1, 1),
+        meta_injector.buffer
+    )
+
+    return [kernel]

--- a/src/graph_transpiler/webdnn/graph/operators/concat.py
+++ b/src/graph_transpiler/webdnn/graph/operators/concat.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from webdnn.graph.axis import Axis
 from webdnn.graph.operator import Operator
@@ -14,7 +14,7 @@ class Concat(Operator):
         axis (:obj:~`graph_transpiler.graph.axis.Axis`): target axis
     """
 
-    def __init__(self, name: str, axis: Axis):
+    def __init__(self, name: Optional[str], axis: Axis):
         super().__init__(name)
         self.parameters["axis"] = axis
         self.attributes = {Elementwise(self)}
@@ -45,3 +45,7 @@ class Concat(Operator):
         y = Variable(y_shape, xs[0].order)
         self.append_output("y", y)
         return y,
+
+    @property
+    def axis(self) -> Axis:
+        return self.parameters["axis"]

--- a/test/README.md
+++ b/test/README.md
@@ -24,7 +24,7 @@
     - 予め、テスト用のカーネルコードを生成する必要がある
     
         ```
-        nosetests nosetests -w ./test/kernels
+        nosetests -w ./test/kernels
         ```
 
     - `kernel_test.html` を開いて[RUN]を押すと生成されたカーネルコードがテストされる。

--- a/test/kernels/concat_test.py
+++ b/test/kernels/concat_test.py
@@ -23,7 +23,7 @@ def test_major_axis():
 
     generate_kernel_test_case(
         description=f"concat_in_major_axis",
-        backend=["webgpu"],
+        backend=["webgpu", "webassembly"],
         graph=Graph([x1, x2, x3, x4], [y]),
         inputs={
             x1: vx1,

--- a/test/kernels/concat_test.py
+++ b/test/kernels/concat_test.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from test.util import generate_kernel_test_case
+from webdnn.graph.axis import Axis
+from webdnn.graph.graph import Graph
+from webdnn.graph.operators.concat import Concat
+from webdnn.graph.order import OrderNHWC
+from webdnn.graph.variable import Variable
+
+
+def test_major_axis():
+    vx1 = np.random.rand(2, 3, 4, 5)
+    vx2 = np.random.rand(2, 3, 4, 5)
+    vx3 = np.random.rand(2, 3, 4, 5)
+    vx4 = np.random.rand(2, 3, 4, 5)
+    vy = np.concatenate((vx1, vx2, vx3, vx4), 0)
+
+    x1 = Variable(vx1.shape, order=OrderNHWC)
+    x2 = Variable(vx2.shape, order=OrderNHWC)
+    x3 = Variable(vx3.shape, order=OrderNHWC)
+    x4 = Variable(vx4.shape, order=OrderNHWC)
+    y, = Concat(None, axis=Axis.N)(x1, x2, x3, x4)
+
+    generate_kernel_test_case(
+        description=f"concat_in_major_axis",
+        backend=["webgpu"],
+        graph=Graph([x1, x2, x3, x4], [y]),
+        inputs={
+            x1: vx1,
+            x2: vx2,
+            x3: vx3,
+            x4: vx4
+        },
+        expected={y: vy}
+    )


### PR DESCRIPTION
I implemented `Concat` operation. This implementation is very naive and only support major(most-outside) axis concatenation.