### PR TITLE
Update es5 tips in docs

### DIFF
--- a/docs/source/tips/es5.md
+++ b/docs/source/tips/es5.md
@@ -10,7 +10,7 @@ In colusion, you need to insert the following statements in the html.
 
 ```
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js"></script>
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch&flags=gated"></script>
 <script src="../../lib/inflate.min.js"></script>
 <script src="../../dist/webdnn.es5.js"></script>
 ```


### PR DESCRIPTION
The parameter `flags=gated` should better be added when using the polyfill. (See https://css-tricks.com/polyfill-javascript-need/#article-header-id-5) Otherwise the polyfill will overwrite the original `fetch` in some browsers (e.g. Mobile Safari on iOS 10.3.3) and cause some problems.