### PR TITLE
fix progress display

### DIFF
--- a/dist/webdnn.es5.js
+++ b/dist/webdnn.es5.js
@@ -1756,7 +1756,7 @@ var DescriptorRunnerWebGL = (function (_super) {
                     case 0: return [4 /*yield*/, Promise.all([
                             webdnnFetch(directory + "/graph_" + this.backendName + ".json", { ignoreCache: this.ignoreCache })
                                 .then(function (res) { return res.json(); }),
-                            webdnnFetch(directory + "/weight_" + this.backendName + ".bin", { ignoreCache: this.ignoreCache })
+                            webdnnFetch(directory + "/weight_" + this.backendName + ".bin", { ignoreCache: this.ignoreCache, progressCallback: progressCallback })
                                 .then(function (res) { return readArrayBufferProgressively(res, progressCallback); })
                         ])];
                     case 1:
@@ -2523,7 +2523,7 @@ var DescriptorRunnerWebGPU = (function (_super) {
                     case 0: return [4 /*yield*/, Promise.all([
                             webdnnFetch(directory + "/graph_" + this.backendName + ".json", { ignoreCache: this.ignoreCache })
                                 .then(function (res) { return res.json(); }),
-                            webdnnFetch(directory + "/weight_" + this.backendName + ".bin", { ignoreCache: this.ignoreCache })
+                            webdnnFetch(directory + "/weight_" + this.backendName + ".bin", { ignoreCache: this.ignoreCache, progressCallback: progressCallback })
                                 .then(function (res) { return readArrayBufferProgressively(res, progressCallback); })
                         ])];
                     case 1:

--- a/dist/webdnn.js
+++ b/dist/webdnn.js
@@ -1471,7 +1471,7 @@ class DescriptorRunnerWebGL extends DescriptorRunner {
             let [descriptor, weightRawArray] = yield Promise.all([
                 webdnnFetch(`${directory}/graph_${this.backendName}.json`, { ignoreCache: this.ignoreCache })
                     .then(res => res.json()),
-                webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache })
+                webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache, progressCallback: progressCallback })
                     .then(res => readArrayBufferProgressively(res, progressCallback))
             ]);
             yield this.setDescriptor(descriptor);
@@ -2046,7 +2046,7 @@ using namespace metal;
             let [descriptor, weightRawArray] = yield Promise.all([
                 webdnnFetch(`${directory}/graph_${this.backendName}.json`, { ignoreCache: this.ignoreCache })
                     .then(res => res.json()),
-                webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache })
+                webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache, progressCallback: progressCallback })
                     .then(res => readArrayBufferProgressively(res, progressCallback))
             ]);
             yield this.setDescriptor(descriptor);

--- a/src/descriptor_runner/descriptor_runner/descriptor_runner_webgl.ts
+++ b/src/descriptor_runner/descriptor_runner/descriptor_runner_webgl.ts
@@ -97,7 +97,7 @@ export default class DescriptorRunnerWebGL extends DescriptorRunner<GraphDescrip
             webdnnFetch(`${directory}/graph_${this.backendName}.json`, {ignoreCache: this.ignoreCache})
                 .then(res => res.json() as Promise<GraphDescriptorWebGL>),
 
-            webdnnFetch(`${directory}/weight_${this.backendName}.bin`, {ignoreCache: this.ignoreCache})
+            webdnnFetch(`${directory}/weight_${this.backendName}.bin`, {ignoreCache: this.ignoreCache, progressCallback: progressCallback})
                 .then(res => readArrayBufferProgressively(res, progressCallback))
         ]);
 

--- a/src/descriptor_runner/descriptor_runner/descriptor_runner_webgpu.ts
+++ b/src/descriptor_runner/descriptor_runner/descriptor_runner_webgpu.ts
@@ -105,7 +105,7 @@ using namespace metal;
             webdnnFetch(`${directory}/graph_${this.backendName}.json`, { ignoreCache: this.ignoreCache })
                 .then(res => res.json() as Promise<GraphDescriptorWebGPU>),
 
-            webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache })
+            webdnnFetch(`${directory}/weight_${this.backendName}.bin`, { ignoreCache: this.ignoreCache, progressCallback: progressCallback })
                 .then(res => readArrayBufferProgressively(res, progressCallback))
         ]);
 


### PR DESCRIPTION
I modified function `webDNNFetch` before. It utilizes XHR2 instead of Fetch API if XHR2 is supported. 
But XHR2 will start fetching data as soon as the request is sent. Thus, data fetching is actually done in `webDNNFetch` rather than `readArrayBufferProgressively`. In this case, `readArrayBufferProgressively` is "short-circuited". In order to show progress while fetching data, we have to pass `progressCallback` to `webDNNFetch`.

(You may reject this PR if there is a better solution.)