### PR TITLE
added 'await' to getImageArray in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ async function init() {
 
 async function run() {
     // Set the value into input variable.
-    runner.getInputViews()[0].set(WebDNN.Image.getImageArray('./input_image.png'));
+    runner.getInputViews()[0].set(await WebDNN.Image.getImageArray('./input_image.png'));
     
     // Run
     await runner.run(); 

--- a/README_ja.md
+++ b/README_ja.md
@@ -68,7 +68,7 @@ async function init() {
 
 async function run() {
     // 入力変数にデータをセット
-    runner.getInputViews()[0].set(WebDNN.Image.getImageArray('./input_image.png'));
+    runner.getInputViews()[0].set(await WebDNN.Image.getImageArray('./input_image.png'));
     
     // 実行
     await runner.run(); 


### PR DESCRIPTION
When I copy & paste the code from the readme, the runner will run before the image is loaded and the results will be wrong. I added `await` to fix this.