### PR TITLE
Implement Chainer's F.unpooling_2d 

### DIFF
--- a/src/graph_transpiler/webdnn/backend/webassembly/kernels/__init__.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/kernels/__init__.py
@@ -37,4 +37,5 @@ from webdnn.backend.webassembly.kernels import split_axis
 from webdnn.backend.webassembly.kernels import tanh
 from webdnn.backend.webassembly.kernels import threshold_relu
 from webdnn.backend.webassembly.kernels import transpose
+from webdnn.backend.webassembly.kernels import unpooling_2d
 from webdnn.backend.webassembly.kernels import zero_padding_1d

--- a/src/graph_transpiler/webdnn/backend/webassembly/kernels/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/kernels/unpooling_2d.py
@@ -1,0 +1,97 @@
+from typing import List
+
+from webdnn.backend.code_generator.allocator import MemoryLayout
+from webdnn.backend.code_generator.injectors.buffer_injector import BufferInjector
+from webdnn.backend.code_generator.injectors.kernel_name_injector import KernelNameInjector
+from webdnn.backend.webassembly.generator import WebassemblyDescriptorGenerator
+from webdnn.backend.webassembly.kernel import Kernel
+from webdnn.graph.axis import Axis
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
+from webdnn.graph.order import OrderNHWC
+
+template = """
+void %%FUNC_NAME%%(const int * %%META_BUFFER%%)
+{
+    const float *X = %%LOAD_BUFFER(unpooling_2d_x)%%;
+    float *Y = %%LOAD_BUFFER(unpooling_2d_Y)%%;
+    const int N = %%LOAD_BUFFER(unpooling_2d_N)%%;
+    const int H1 = %%LOAD_BUFFER(unpooling_2d_H1)%%;
+    const int W1 = %%LOAD_BUFFER(unpooling_2d_W1)%%;
+    const int C = %%LOAD_BUFFER(unpooling_2d_C)%%;
+    const int H2 = %%LOAD_BUFFER(unpooling_2d_H2)%%;
+    const int W2 = %%LOAD_BUFFER(unpooling_2d_W2)%%;
+
+    const int KH = %%LOAD_BUFFER(unpooling_2d_KH)%%;
+    const int KW = %%LOAD_BUFFER(unpooling_2d_KW)%%;
+    const int SH = %%LOAD_BUFFER(unpooling_2d_SH)%%;
+    const int SW = %%LOAD_BUFFER(unpooling_2d_SW)%%;
+    const int PH = %%LOAD_BUFFER(unpooling_2d_PH)%%;
+    const int PW = %%LOAD_BUFFER(unpooling_2d_PW)%%;
+
+    for (int gid = 0; gid < N * H2 * W2 * C; gid += 1) {
+        const int c = gid % C;
+        const int w2 = gid / C % W2;
+        const int h2 = gid / C / W2 % H2;
+        const int n = gid / C / W2 / H2;
+
+        float v = 0;
+        for (int kh = 0; kh < KH; kh++) {
+            int h1 = h2 + PH - kh;
+            if (h1 < 0 || h1 >= H1 * SH) continue;
+            if (h1 % SH != 0) continue;
+            h1 /= SH;
+            for (int kw = 0; kw < KW; kw++) {
+                int w1 = w2 + PW - kw;
+                if (w1 < 0 || w1 >= W1 * SW) continue;
+                if (w1 % SW != 0) continue;
+                out_x /= SW;
+                v += X[((n * H1 + h1) * W1 + w1) * C + c];
+            }
+        }
+
+        Y[gid] = v;
+    }
+}
+"""
+
+@WebassemblyDescriptorGenerator.register_handler(Unpooling2D)
+def unpooling_2d(op: Unpooling2D,
+                       memory_layout: MemoryLayout) -> List[Kernel]:
+    x = op.inputs["x"]
+    y = op.outputs["y"]
+
+    assert x.order == OrderNHWC
+    assert y.order == OrderNHWC
+
+    buffer_injector = BufferInjector()
+    buffer_injector.register({
+        "unpooling_2d_x": memory_layout[x],
+        "unpooling_2d_Y": memory_layout[y],
+        "unpooling_2d_N": x.shape_dict[Axis.N],
+        "unpooling_2d_H1": x.shape_dict[Axis.H],
+        "unpooling_2d_W1": x.shape_dict[Axis.W],
+        "unpooling_2d_C": x.shape_dict[Axis.C],
+        "unpooling_2d_H2": y.shape_dict[Axis.H],
+        "unpooling_2d_W2": y.shape_dict[Axis.W],
+        "unpooling_2d_KH": op.parameters["ksize"][0],
+        "unpooling_2d_KW": op.parameters["ksize"][1],
+        "unpooling_2d_SH": op.parameters["stride"][0],
+        "unpooling_2d_SW": op.parameters["stride"][1],
+        "unpooling_2d_PH": op.parameters["padding"][0],
+        "unpooling_2d_PW": op.parameters["padding"][1],
+    })
+
+    name_injector = KernelNameInjector(op)
+
+    source = template
+    source = buffer_injector.inject(source)
+    source = name_injector.inject(source)
+
+    kernel = Kernel(
+        {name_injector.name: source},
+        name_injector.name,
+        buffer_injector.buffer,
+        buffer_injector.unresolved_value_list
+    )
+
+    return [kernel]

--- a/src/graph_transpiler/webdnn/backend/webassembly/kernels/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/kernels/unpooling_2d.py
@@ -44,7 +44,7 @@ void %%FUNC_NAME%%(const int * %%META_BUFFER%%)
                 int w1 = w2 + PW - kw;
                 if (w1 < 0 || w1 >= W1 * SW) continue;
                 if (w1 % SW != 0) continue;
-                out_x /= SW;
+                w1 /= SW;
                 v += X[((n * H1 + h1) * W1 + w1) * C + c];
             }
         }

--- a/src/graph_transpiler/webdnn/backend/webassembly/optimize_rules/insert_transpose.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/optimize_rules/insert_transpose.py
@@ -11,6 +11,7 @@ from webdnn.graph.operators.depth2space import Depth2Space
 from webdnn.graph.operators.elementwise import Elementwise
 from webdnn.graph.operators.local_response_normalization import LocalResponseNormalization
 from webdnn.graph.operators.max_pooling_2d import MaxPooling2D
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
 from webdnn.graph.operators.reshape import Reshape
 from webdnn.graph.operators.softmax import Softmax
 from webdnn.graph.operators.space2depth import Space2Depth
@@ -92,7 +93,8 @@ class InsertTranspose(OptimizeRule):
             elif isinstance(op, (Convolution2D, Deconvolution2D,
                                  MaxPooling2D, AveragePooling2D,
                                  Space2Depth, Depth2Space,
-                                 LocalResponseNormalization)):
+                                 LocalResponseNormalization,
+                                 Unpooling2D)):
                 flag_changed |= _replace_input(op, "x", OrderNHWC)
                 flag_changed |= _replace_output(op, "y", OrderNHWC)
                 continue

--- a/src/graph_transpiler/webdnn/backend/webgl/kernels/__init__.py
+++ b/src/graph_transpiler/webdnn/backend/webgl/kernels/__init__.py
@@ -40,4 +40,5 @@ from webdnn.backend.webgl.kernels import sum
 from webdnn.backend.webgl.kernels import tanh
 from webdnn.backend.webgl.kernels import threshold_relu
 from webdnn.backend.webgl.kernels import transpose
+from webdnn.backend.webgl.kernels import unpooling_2d
 from webdnn.backend.webgl.kernels import util

--- a/src/graph_transpiler/webdnn/backend/webgl/kernels/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/backend/webgl/kernels/unpooling_2d.py
@@ -1,0 +1,108 @@
+from typing import List
+
+from webdnn.backend.code_generator.injectors.kernel_name_injector import KernelNameInjector
+from webdnn.backend.webgl.generator import WebGLDescriptorGenerator
+from webdnn.backend.webgl.kernel import Kernel
+from webdnn.backend.webgl.kernels.util import FragmentShaderPreamble, texture_stride, texture_shape
+from webdnn.backend.webgl.uniform_injector import UniformInjector
+from webdnn.graph.axis import Axis
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
+from webdnn.graph.order import OrderNHWC
+
+
+def generate_template(ksize):
+    return FragmentShaderPreamble + """
+    %%UNIFORM(sampler2D, X)%%;
+
+    %%UNIFORM(vec2, s_y)%%;
+    %%UNIFORM(vec4, d_Y)%%;
+    %%UNIFORM(vec4, s_Y)%%;
+
+    %%UNIFORM(vec2, d_x)%%;
+    %%UNIFORM(vec2, s_x)%%;
+    %%UNIFORM(vec4, s_X)%%;
+
+    %%UNIFORM(int, C1)%%;
+    %%UNIFORM(int, H1)%%;
+    %%UNIFORM(int, W1)%%;
+    %%UNIFORM(int, SH)%%;
+    %%UNIFORM(int, SW)%%;
+    %%UNIFORM(int, PH)%%;
+    %%UNIFORM(int, PW)%%;
+
+    void main() {
+        ivec4 p_Y = convert_position_i(gl_FragCoord.xy, s_y, s_Y, d_Y);
+        int n = p_Y.x;
+        int h2 = p_Y.y;
+        int w2 = p_Y.z;
+        int c = p_Y.w;
+
+        float sum = 0.0;
+
+        for (int kh = 0; kh < %%KSIZE_H%%; kh++) {
+            int h1 = h2 + PH - kh;
+            if (h1 < 0 || h1 >= H1 * SH) continue;
+            int mod_sh = h1 - h1 / SH * SH;
+            if (mod_sh != 0) continue;
+            h1 /= SH;
+            for (int kw = 0; kw < %%KSIZE_W%%; kw++) {
+                int w1 = w2 + PW - kw;
+                if (w1 < 0 || w1 >= W1 * SW) continue;
+                int mod_sw = w1 - w1 / SW * SW;
+                if (mod_sw != 0) continue;
+                w1 /= SW;
+
+                sum += texture2D(X, convert_coord(vec4(n, h1, w1, c) + 0.5, s_X, s_x, d_x)).r;
+            }
+        }
+
+        gl_FragColor = vec4(sum, 0, 0, 0);
+    }
+    """ \
+        .replace("%%KSIZE_H%%", f"{ksize[0]}") \
+        .replace("%%KSIZE_W%%", f"{ksize[1]}")
+
+
+@WebGLDescriptorGenerator.register_handler(Unpooling2D)
+def average_pooling_2d(op: Unpooling2D) -> List[Kernel]:
+    x = op.inputs["x"]
+    y = op.outputs["y"]
+
+    assert x.order == OrderNHWC
+    assert y.order == OrderNHWC
+
+    name_injector = KernelNameInjector(op)
+    uniform_injector = UniformInjector()
+
+    uniform_injector.register({
+        "X": x,
+
+        "s_y": texture_stride(y),
+        "d_Y": y.shape,
+        "s_Y": y.stride,
+
+        "d_x": texture_shape(x),
+        "s_x": texture_stride(x),
+        "s_X": x.stride,
+
+        "C1": x.shape_dict[Axis.C],
+        "H1": x.shape_dict[Axis.H],
+        "W1": x.shape_dict[Axis.W],
+        "SH": op.parameters["stride"][0],
+        "SW": op.parameters["stride"][1],
+        "PH": op.parameters["padding"][0],
+        "PW": op.parameters["padding"][1],
+    })
+
+    source = generate_template(ksize=op.parameters["ksize"])
+    source = uniform_injector.inject(source)
+    source = name_injector.inject(source)
+    kernel = Kernel(
+        source,
+        name_injector.name,
+        uniform_injector.samplers,
+        uniform_injector.uniforms,
+        y
+    )
+
+    return [kernel]

--- a/src/graph_transpiler/webdnn/backend/webgl/optimize_rules/insert_transpose.py
+++ b/src/graph_transpiler/webdnn/backend/webgl/optimize_rules/insert_transpose.py
@@ -11,6 +11,7 @@ from webdnn.graph.operators.depth2space import Depth2Space
 from webdnn.graph.operators.elementwise import Elementwise
 from webdnn.graph.operators.im2col import Im2Col
 from webdnn.graph.operators.max_pooling_2d import MaxPooling2D
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
 from webdnn.graph.operators.reshape import Reshape
 from webdnn.graph.operators.space2depth import Space2Depth
 from webdnn.graph.operators.split_axis import SplitAxis
@@ -121,7 +122,7 @@ class InsertTranspose(OptimizeRule):
                 flag_changed |= _replace_output(op, "im", OrderNHWC)
                 continue
 
-            elif isinstance(op, (Convolution2D, Deconvolution2D, MaxPooling2D, AveragePooling2D, Space2Depth, Depth2Space)):
+            elif isinstance(op, (Convolution2D, Deconvolution2D, MaxPooling2D, AveragePooling2D, Space2Depth, Depth2Space, Unpooling2D)):
                 flag_changed |= _replace_input(op, "x", OrderNHWC)
                 flag_changed |= _replace_output(op, "y", OrderNHWC)
                 continue

--- a/src/graph_transpiler/webdnn/backend/webgpu/kernels/__init__.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/kernels/__init__.py
@@ -37,4 +37,5 @@ from webdnn.backend.webgpu.kernels import split_axis
 from webdnn.backend.webgpu.kernels import tanh
 from webdnn.backend.webgpu.kernels import threshold_relu
 from webdnn.backend.webgpu.kernels import transpose
+from webdnn.backend.webgpu.kernels import unpooling_2d
 from webdnn.backend.webgpu.kernels import zero_padding_1d

--- a/src/graph_transpiler/webdnn/backend/webgpu/kernels/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/kernels/unpooling_2d.py
@@ -1,0 +1,105 @@
+from typing import List
+
+from webdnn.backend.code_generator.allocator import MemoryLayout
+from webdnn.backend.code_generator.injectors.buffer_injector import BufferInjector
+from webdnn.backend.code_generator.injectors.kernel_name_injector import KernelNameInjector
+from webdnn.backend.webgpu.generator import WebGPUDescriptorGenerator
+from webdnn.backend.webgpu.kernel import Kernel, GPUSize
+from webdnn.backend.webgpu.preset_placeholders import MAX_THREADS_PER_THREADGROUP
+from webdnn.graph.axis import Axis
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
+from webdnn.graph.order import OrderNHWC
+
+template = """
+kernel void %%FUNC_NAME%%(device float * %%STATIC_BUFFER%%[[buffer(0)]],
+                          device float * %%DYNAMIC_BUFFER%%[[buffer(1)]],
+                          const device int * %%META_BUFFER%% [[buffer(2)]],
+                          uint index[[thread_position_in_grid]],
+                          uint num_threads[[threads_per_grid]])
+{
+    const device float *X = %%LOAD_BUFFER(unpooling_2d_X)%%;
+    device float *Y = %%LOAD_BUFFER(unpooling_2d_Y)%%;
+    const int N = %%LOAD_BUFFER(unpooling_2d_N)%%;
+    const int H1 = %%LOAD_BUFFER(unpooling_2d_H1)%%;
+    const int W1 = %%LOAD_BUFFER(unpooling_2d_W1)%%;
+    const int C = %%LOAD_BUFFER(unpooling_2d_C)%%;
+    const int H2 = %%LOAD_BUFFER(unpooling_2d_H2)%%;
+    const int W2 = %%LOAD_BUFFER(unpooling_2d_W2)%%;
+
+    const int KH = %%LOAD_BUFFER(unpooling_2d_KH)%%;
+    const int KW = %%LOAD_BUFFER(unpooling_2d_KW)%%;
+    const int SH = %%LOAD_BUFFER(unpooling_2d_SH)%%;
+    const int SW = %%LOAD_BUFFER(unpooling_2d_SW)%%;
+    const int PH = %%LOAD_BUFFER(unpooling_2d_PH)%%;
+    const int PW = %%LOAD_BUFFER(unpooling_2d_PW)%%;
+
+    for (int gid = index; gid < N * H2 * W2 * C; gid += num_threads) {
+        const int c = gid % C;
+        const int w2 = gid / C % W2;
+        const int h2 = gid / C / W2 % H2;
+        const int n = gid / C / W2 / H2;
+
+        float v = 0;
+        for (int kh = 0; kh < KH; kh++) {
+            int h1 = h2 + PH - kh;
+            if (h1 < 0 || h1 >= H1 * SH) continue;
+            if (h1 % SH != 0) continue;
+            h1 /= SH;
+            for (int kw = 0; kw < KW; kw++) {
+                int w1 = w2 + PW - kw;
+                if (w1 < 0 || w1 >= W1 * SW) continue;
+                if (w1 % SW != 0) continue;
+                w1 /= SW;
+                v += X[((n * H1 + h1) * W1 + w1) * C + c];
+            }
+        }
+
+        Y[gid] = v;
+    }
+}
+"""
+
+
+@WebGPUDescriptorGenerator.register_handler(Unpooling2D)
+def average_pooling_2d(op: Unpooling2D,
+                       memory_layout: MemoryLayout) -> List[Kernel]:
+    x = op.inputs["x"]
+    y = op.outputs["y"]
+
+    assert x.order == OrderNHWC
+    assert y.order == OrderNHWC
+
+    buffer_injector = BufferInjector()
+    buffer_injector.register({
+        "unpooling_2d_X": memory_layout[x],
+        "unpooling_2d_Y": memory_layout[y],
+        "unpooling_2d_N": x.shape_dict[Axis.N],
+        "unpooling_2d_H1": x.shape_dict[Axis.H],
+        "unpooling_2d_W1": x.shape_dict[Axis.W],
+        "unpooling_2d_C": x.shape_dict[Axis.C],
+        "unpooling_2d_H2": y.shape_dict[Axis.H],
+        "unpooling_2d_W2": y.shape_dict[Axis.W],
+        "unpooling_2d_KH": op.parameters["ksize"][0],
+        "unpooling_2d_KW": op.parameters["ksize"][1],
+        "unpooling_2d_SH": op.parameters["stride"][0],
+        "unpooling_2d_SW": op.parameters["stride"][1],
+        "unpooling_2d_PH": op.parameters["padding"][0],
+        "unpooling_2d_PW": op.parameters["padding"][1],
+    })
+
+    name_injector = KernelNameInjector(op)
+
+    source = template
+    source = buffer_injector.inject(source)
+    source = name_injector.inject(source)
+
+    kernel = Kernel(
+        {name_injector.name: source},
+        name_injector.name,
+        GPUSize(8, 1, 1),
+        GPUSize(MAX_THREADS_PER_THREADGROUP, 1, 1),
+        buffer_injector.buffer,
+        buffer_injector.unresolved_value_list
+    )
+
+    return [kernel]

--- a/src/graph_transpiler/webdnn/backend/webgpu/optimize_rules/insert_transpose.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/optimize_rules/insert_transpose.py
@@ -10,6 +10,7 @@ from webdnn.graph.operators.deconvolution2d import Deconvolution2D
 from webdnn.graph.operators.depth2space import Depth2Space
 from webdnn.graph.operators.local_response_normalization import LocalResponseNormalization
 from webdnn.graph.operators.max_pooling_2d import MaxPooling2D
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
 from webdnn.graph.operators.reshape import Reshape
 from webdnn.graph.operators.softmax import Softmax
 from webdnn.graph.operators.space2depth import Space2Depth
@@ -64,7 +65,8 @@ class InsertTranspose(OptimizeRule):
             elif isinstance(op, (Convolution2D, Deconvolution2D,
                                  MaxPooling2D, AveragePooling2D,
                                  Space2Depth, Depth2Space,
-                                 LocalResponseNormalization)):
+                                 LocalResponseNormalization,
+                                 Unpooling2D)):
                 flag_changed |= _replace_input(op, "x", OrderNHWC)
                 flag_changed |= _replace_output(op, "y", OrderNHWC)
                 continue

--- a/src/graph_transpiler/webdnn/frontend/chainer/functions/pooling.py
+++ b/src/graph_transpiler/webdnn/frontend/chainer/functions/pooling.py
@@ -90,7 +90,7 @@ def _convert_unpooling2d(converter: ChainerConverter, c_op: "chainer.functions.U
                            ksize=(c_op.kh, c_op.kw),
                            stride=(c_op.sy, c_op.sx),
                            padding=(c_op.ph, c_op.pw),
-                           cover_all=c_op.cover_all)
+                           outsize=(c_op.outh, c_op.outw))
 
     y, = pool_opr(x)
 

--- a/src/graph_transpiler/webdnn/frontend/chainer/functions/pooling.py
+++ b/src/graph_transpiler/webdnn/frontend/chainer/functions/pooling.py
@@ -5,6 +5,7 @@ from webdnn.frontend.chainer.converter import ChainerConverter
 from webdnn.frontend.constraints import unify_order
 from webdnn.graph.operators.average_pooling_2d import AveragePooling2D
 from webdnn.graph.operators.max_pooling_2d import MaxPooling2D
+from webdnn.graph.operators.unpooling_2d import Unpooling2D
 from webdnn.graph.order import OrderNCHW
 from webdnn.util import console
 
@@ -83,9 +84,17 @@ def _convert_spatial_pyramid_pooling2d(converter: ChainerConverter, c_op: "chain
 # noinspection PyUnusedLocal
 @ChainerConverter.register_handler("Unpooling2D")
 def _convert_unpooling2d(converter: ChainerConverter, c_op: "chainer.functions.Unpooling2D"):
-    # TODO
-    raise NotImplementedError("[ChainerConverter] Unpooling2D is not supported")
+    x = converter.get_variable(c_op.inputs[0])
+    unify_order(x.order, OrderNCHW)
+    pool_opr = Unpooling2D(None,
+                           ksize=(c_op.kh, c_op.kw),
+                           stride=(c_op.sy, c_op.sx),
+                           padding=(c_op.ph, c_op.pw),
+                           cover_all=c_op.cover_all)
 
+    y, = pool_opr(x)
+
+    converter.set_variable(c_op.outputs[0](), y)
 
 # noinspection PyUnusedLocal
 @ChainerConverter.register_handler("UnpoolingND")

--- a/src/graph_transpiler/webdnn/graph/operators/__init__.py
+++ b/src/graph_transpiler/webdnn/graph/operators/__init__.py
@@ -42,6 +42,7 @@ from webdnn.graph.operators import space2depth
 from webdnn.graph.operators import split_axis
 from webdnn.graph.operators import tanh
 from webdnn.graph.operators import threshold_relu
+from webdnn.graph.operators import unpooling_2d
 from webdnn.graph.operators import util
 from webdnn.graph.operators import zero_padding_1d
 from webdnn.graph.operators import zero_padding_2d

--- a/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
@@ -10,7 +10,30 @@ from webdnn.util import console
 
 
 class Unpooling2D(Operator):
-    def __init__(self, name: Optional[str], ksize: IntOrTuple, stride: IntOrTuple, padding: IntOrTuple, outsize: IntOrTuple):
+    """Unpooling2D(name, ksize, stride, padding, outsize)
+
+    Inverse operation of pooling for 2d array.
+    This function acts similarly to :class:`~webdnn.graph.operators.deconvolution2d.Deconvolution2D`, but
+    it spreads input 2d array's value without any parameter instead of
+    computing the inner products.
+
+    Args:
+        name (str): Operator name.
+        ksize (int or tuple of int): Kernel size.
+        stride (int or tuple of int): Stride size.
+        padding (int or tuple of int): Padding size.
+        outsize (int or tuple of int): Output size.
+
+    Signature
+        .. code::
+
+            y, = op(x)
+
+        - **x** - Input variable.
+        - **y** - Output value. Its order is same as :code:`x`.
+    """
+    def __init__(self, name: Optional[str], ksize: IntOrTuple, stride: IntOrTuple, padding: IntOrTuple,
+                 outsize: IntOrTuple):
         super().__init__(name)
         self.parameters["ksize"] = to_tuple(ksize)
         self.parameters["stride"] = to_tuple(stride)

--- a/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
@@ -10,12 +10,12 @@ from webdnn.util import console
 
 
 class Unpooling2D(Operator):
-    def __init__(self, name: Optional[str], ksize: IntOrTuple, stride: IntOrTuple, padding: IntOrTuple, cover_all: bool):
+    def __init__(self, name: Optional[str], ksize: IntOrTuple, stride: IntOrTuple, padding: IntOrTuple, outsize: IntOrTuple):
         super().__init__(name)
         self.parameters["ksize"] = to_tuple(ksize)
         self.parameters["stride"] = to_tuple(stride)
         self.parameters["padding"] = to_tuple(padding)
-        self.parameters['cover_all'] = cover_all
+        self.parameters["outsize"] = to_tuple(outsize)
 
     def __call__(self, x: Variable):
         for axis in x.order.axes:
@@ -31,16 +31,8 @@ class Unpooling2D(Operator):
         x = self.inputs["x"]
         x_shape_dict = x.shape_dict
         N = x_shape_dict[Axis.N]
-        if self.parameters['cover_all']:
-            H2 = (x_shape_dict[Axis.H] - 1) * self.parameters["stride"][0] + self.parameters["ksize"][0] - \
-                self.parameters["stride"][0] + 1 - 2 * self.parameters["padding"][0]
-            W2 = (x_shape_dict[Axis.W] - 1) * self.parameters["stride"][1] + self.parameters["ksize"][1] - \
-                self.parameters["stride"][1] + 1 - 2 * self.parameters["padding"][1]
-        else:
-            H2 = (x_shape_dict[Axis.H] - 1) * self.parameters["stride"][0] + self.parameters["ksize"][0] - \
-                  2 * self.parameters["padding"][0]
-            W2 = (x_shape_dict[Axis.W] - 1) * self.parameters["stride"][1] + self.parameters["ksize"][1] - \
-                  2 * self.parameters["padding"][1]
+        H2 = self.parameters["outsize"][0]
+        W2 = self.parameters["outsize"][1]
         C2 = x_shape_dict[Axis.C]
         y = Variable([N, H2, W2, C2], OrderNHWC)
         y.change_order(x.order)  # output same order as input to preserve following reshape semantics

--- a/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
+++ b/src/graph_transpiler/webdnn/graph/operators/unpooling_2d.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from webdnn.graph.axis import Axis
+from webdnn.graph.operator import Operator
+from webdnn.graph.operators.attributes.tensorwise import Tensorwise
+from webdnn.graph.operators.util import IntOrTuple, to_tuple
+from webdnn.graph.order import OrderNHWC
+from webdnn.graph.variable import Variable
+from webdnn.util import console
+
+
+class Unpooling2D(Operator):
+    def __init__(self, name: Optional[str], ksize: IntOrTuple, stride: IntOrTuple, padding: IntOrTuple, cover_all: bool):
+        super().__init__(name)
+        self.parameters["ksize"] = to_tuple(ksize)
+        self.parameters["stride"] = to_tuple(stride)
+        self.parameters["padding"] = to_tuple(padding)
+        self.parameters['cover_all'] = cover_all
+
+    def __call__(self, x: Variable):
+        for axis in x.order.axes:
+            if axis == Axis.H or axis == Axis.W:
+                continue
+
+            self.attributes.add(Tensorwise(self, axis))
+
+        self.append_input("x", x)
+        return self.exec()
+
+    def exec(self):
+        x = self.inputs["x"]
+        x_shape_dict = x.shape_dict
+        N = x_shape_dict[Axis.N]
+        if self.parameters['cover_all']:
+            H2 = (x_shape_dict[Axis.H] - 1) * self.parameters["stride"][0] + self.parameters["ksize"][0] - \
+                self.parameters["stride"][0] + 1 - 2 * self.parameters["padding"][0]
+            W2 = (x_shape_dict[Axis.W] - 1) * self.parameters["stride"][1] + self.parameters["ksize"][1] - \
+                self.parameters["stride"][1] + 1 - 2 * self.parameters["padding"][1]
+        else:
+            H2 = (x_shape_dict[Axis.H] - 1) * self.parameters["stride"][0] + self.parameters["ksize"][0] - \
+                  2 * self.parameters["padding"][0]
+            W2 = (x_shape_dict[Axis.W] - 1) * self.parameters["stride"][1] + self.parameters["ksize"][1] - \
+                  2 * self.parameters["padding"][1]
+        C2 = x_shape_dict[Axis.C]
+        y = Variable([N, H2, W2, C2], OrderNHWC)
+        y.change_order(x.order)  # output same order as input to preserve following reshape semantics
+
+        self.append_output("y", y)
+        return y,
+

--- a/test/runtime/frontend_test/chainer_test/unpooling_2d_test.py
+++ b/test/runtime/frontend_test/chainer_test/unpooling_2d_test.py
@@ -4,7 +4,37 @@ import numpy as np
 from test.util import generate_kernel_test_case, wrap_template
 from webdnn.frontend.chainer.converter import ChainerConverter
 
+
 @wrap_template
-def template(ksize=2, stride=None, pad=0, shape=(2, 4, 6, 8), description=""):
+def template(ksize=2, stride=None, pad=0, cover_all=True, shape=(2, 4, 6, 8), description=""):
     vx = chainer.Variable(np.random.rand(*shape).astype(np.float32))
-    vy = chainer.functions.average_pooling_2d(vx, ksize=ksize, stride=stride, pad=pad)
+    vy = chainer.functions.unpooling_2d(vx, ksize=ksize, stride=stride, pad=pad, cover_all=cover_all)
+
+    graph = ChainerConverter().convert([vx], [vy])
+
+    x = graph.inputs[0]
+    y = graph.outputs[0]
+
+    generate_kernel_test_case(
+        description=f"[chainer] F.unpooling_2d {description}",
+        graph=graph,
+        backend=["webgpu", "webgl", "webassembly"],
+        inputs={x: vx.data},
+        expected={y: vy.data},
+    )
+
+
+def test():
+    template()
+
+def test_padding_not_zero():
+    template(pad=1)
+
+def test_stride_is_none():
+    template(stride=None, pad=1)
+
+def test_cover_all_fasle():
+    template(stride=2, cover_all=False)
+
+def test_irregular_size():
+    template(ksize=(3, 4), stride=(1, 2), pad=(1, 3))

--- a/test/runtime/frontend_test/chainer_test/unpooling_2d_test.py
+++ b/test/runtime/frontend_test/chainer_test/unpooling_2d_test.py
@@ -1,0 +1,10 @@
+import chainer
+import numpy as np
+
+from test.util import generate_kernel_test_case, wrap_template
+from webdnn.frontend.chainer.converter import ChainerConverter
+
+@wrap_template
+def template(ksize=2, stride=None, pad=0, shape=(2, 4, 6, 8), description=""):
+    vx = chainer.Variable(np.random.rand(*shape).astype(np.float32))
+    vy = chainer.functions.average_pooling_2d(vx, ksize=ksize, stride=stride, pad=pad)


### PR DESCRIPTION
This PR contains `F.unpooling_2d` implemented with WASM/WebGPU/WebGL backends.
I use `F.unpooling_2d(x, 2, 2, 0, cover_all=False)`  to do nearest neighborhood upsampling instead of subpixel convolution in my new model.
