### PR TITLE
append timestamp in graph descriptor

### DIFF
--- a/src/descriptor_runner/graph_descriptor/graph_descriptor.ts
+++ b/src/descriptor_runner/graph_descriptor/graph_descriptor.ts
@@ -11,6 +11,11 @@ import { MemoryLayout } from "./memory_layout";
  */
 export interface GraphDescriptor {
     /**
+     * Unix timestamp when this graph descriptor is generated
+     */
+    converted_at: number;
+
+    /**
      * input variables' name
      */
     inputs: string[];

--- a/src/graph_transpiler/webdnn/backend/fallback/graph_descriptor.py
+++ b/src/graph_transpiler/webdnn/backend/fallback/graph_descriptor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 from typing import Iterable, Dict, Set
 
 from webdnn.backend.code_generator.allocator import MemoryLayout
@@ -75,6 +76,7 @@ class GraphDescriptor(json.SerializableMixin, IGraphDescriptor):
         placeholders = self.get_all_placeholders()
 
         return {
+            "converted_at": int(datetime.timestamp(datetime.now())),
             "kernel_source": self.concat_kernel_sources(),
             "exec_infos": [kernel.exec_info for kernel in self.kernels],
             "weight_encoding": self.constants_encoding,

--- a/src/graph_transpiler/webdnn/backend/webassembly/graph_descriptor.py
+++ b/src/graph_transpiler/webdnn/backend/webassembly/graph_descriptor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 from typing import Dict, Iterable, List, Set, Tuple
 
 import numpy as np
@@ -159,6 +160,7 @@ class GraphDescriptor(json.SerializableMixin, IGraphDescriptor):
             unresolved_value_lists.append([{"offset": v[0], "placeholder": v[1]} for v in unresolved_value_list])
 
         return {
+            "converted_at": int(datetime.timestamp(datetime.now())),
             "weight_encoding": self.constants_encoding,
             "memory_layout": self.memory_layout,
             "placeholders": placeholders,

--- a/src/graph_transpiler/webdnn/backend/webgl/graph_descriptor.py
+++ b/src/graph_transpiler/webdnn/backend/webgl/graph_descriptor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 from typing import Iterable, Dict, Any
 
 from webdnn.backend.interface.graph_descriptor import IGraphDescriptor
@@ -50,6 +51,7 @@ class GraphDescriptor(json.SerializableMixin, IGraphDescriptor):
         placeholders = []
 
         return {
+            "converted_at": int(datetime.timestamp(datetime.now())),
             "inputs": [v.parameters["name"] for v in self.inputs if not traverse.check_attribute_match(v, Constant)],
             "outputs": [v.parameters["name"] for v in self.outputs],
             "memory_layout": self.memory_layout,

--- a/src/graph_transpiler/webdnn/backend/webgpu/graph_descriptor.py
+++ b/src/graph_transpiler/webdnn/backend/webgpu/graph_descriptor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from datetime import datetime
 from typing import Iterable, Dict, List, Set, Tuple
 
 from webdnn.backend.code_generator.allocator import MemoryLayout
@@ -83,6 +84,7 @@ class GraphDescriptor(json.SerializableMixin, IGraphDescriptor):
         placeholders = self.get_all_placeholders()
 
         return {
+            "converted_at": int(datetime.timestamp(datetime.now())),
             "kernel_source": self.concat_kernel_sources(),
             "exec_infos": [kernel.exec_info for kernel in self.kernels],
             "weight_encoding": self.constants_encoding,


### PR DESCRIPTION
Append the timestamp when the model is converted into graph descriptor.
It's useful for checking if cached model data is expired in client side.