### PR TITLE
add ONNXConverter and PyTorchConverter

### DIFF
--- a/docs/source/api_reference/graph_transpiler/frontend/index.rst
+++ b/docs/source/api_reference/graph_transpiler/frontend/index.rst
@@ -7,9 +7,16 @@ Module :code:`webdnn.frontend` contains model converters for other DNN framework
     :hidden:
     :maxdepth: 1
 
-    ./converter
     ./chainer
+    ./converter
     ./keras
+    ./onnx
+    ./pytorch
+    ./tensorflow
+
+- :doc:`webdnn.frontend.chainer.ChainerConverter<./chainer>`
+
+    Model converter for `Chainer <https://chainer.org/>`_
 
 - :doc:`webdnn.frontend.converter.Converter<./converter>`
 
@@ -17,8 +24,16 @@ Module :code:`webdnn.frontend` contains model converters for other DNN framework
 
 - :doc:`webdnn.frontend.keras.KerasConverter<./keras>`
 
-    Model converter for Keras
+    Model converter for `Keras <https://keras.io>`_
 
-- :doc:`webdnn.frontend.chainer.ChainerConverter<./chainer>`
+- :doc:`webdnn.frontend.onnx.ONNXConverter<./onnx>`
 
-    Model converter for Chainer
+    Model converter for `Open Neural Network Exchange (ONNX) <http://onnx.ai/>`_
+
+- :doc:`webdnn.frontend.pytorch.PyTorchConverter<./pytorch>`
+
+    Model converter for `PyTorch <http://pytorch.org/>`_
+
+- :doc:`webdnn.frontend.tensorflow.TensorFlowConverter<./tensorflow>`
+
+    Model converter for `TensorFlow <https://www.tensorflow.org/>`_

--- a/docs/source/api_reference/graph_transpiler/frontend/onnx.rst
+++ b/docs/source/api_reference/graph_transpiler/frontend/onnx.rst
@@ -1,0 +1,5 @@
+ONNXConverter
+=============
+
+.. autoclass:: webdnn.frontend.onnx.ONNXConverter
+    :members:

--- a/docs/source/api_reference/graph_transpiler/frontend/pytorch.rst
+++ b/docs/source/api_reference/graph_transpiler/frontend/pytorch.rst
@@ -1,0 +1,5 @@
+PyTorchConverter
+================
+
+.. autoclass:: webdnn.frontend.pytorch.PyTorchConverter
+    :members:

--- a/docs/source/api_reference/graph_transpiler/frontend/tensorflow.rst
+++ b/docs/source/api_reference/graph_transpiler/frontend/tensorflow.rst
@@ -1,0 +1,5 @@
+TensorFlowConverter
+===================
+
+.. autoclass:: webdnn.frontend.tensorflow.TensorFlowConverter
+    :members:

--- a/docs/source/api_reference/graph_transpiler/operators.rst
+++ b/docs/source/api_reference/graph_transpiler/operators.rst
@@ -18,6 +18,36 @@ Abs
 .. autoclass:: webdnn.graph.operators.abs.Abs
    :members:
 
+Acos
+----
+.. autoclass:: webdnn.graph.operators.acos.Acos
+   :members:
+
+Acosh
+-----
+.. autoclass:: webdnn.graph.operators.acosh.Acosh
+   :members:
+
+Asin
+----
+.. autoclass:: webdnn.graph.operators.asin.Asin
+   :members:
+
+Asinh
+-----
+.. autoclass:: webdnn.graph.operators.asinh.Asinh
+   :members:
+
+Atan
+----
+.. autoclass:: webdnn.graph.operators.atan.Atan
+   :members:
+
+Atanh
+-----
+.. autoclass:: webdnn.graph.operators.atanh.Atanh
+   :members:
+
 AveragePooling2D
 ----------------
 .. autoclass:: webdnn.graph.operators.average_pooling_2d.AveragePooling2D
@@ -33,9 +63,19 @@ AxiswiseScale
 .. autoclass:: webdnn.graph.operators.axiswise_scale.AxiswiseScale
    :members:
 
+Broadcast
+---------
+.. autoclass:: webdnn.graph.operators.broadcast.Broadcast
+   :members:
+
 ClippedRelu
 -----------
 .. autoclass:: webdnn.graph.operators.clipped_relu.ClippedRelu
+   :members:
+
+Col2Im
+------
+.. autoclass:: webdnn.graph.operators.col2im.Col2Im
    :members:
 
 Concat
@@ -48,9 +88,24 @@ Convolution2D
 .. autoclass:: webdnn.graph.operators.convolution2d.Convolution2D
    :members:
 
+Cos
+---
+.. autoclass:: webdnn.graph.operators.cos.Cos
+   :members:
+
+Cosh
+----
+.. autoclass:: webdnn.graph.operators.cosh.Cosh
+   :members:
+
 Deconvolution2D
 ---------------
 .. autoclass:: webdnn.graph.operators.deconvolution2d.Deconvolution2D
+   :members:
+
+Depth2Space
+-----------
+.. autoclass:: webdnn.graph.operators.depth2space.Depth2Space
    :members:
 
 Elementwise
@@ -78,6 +133,11 @@ ElementwisePow
 .. autoclass:: webdnn.graph.operators.elementwise_pow.ElementwisePow
    :members:
 
+ElementwiseSum
+--------------
+.. autoclass:: webdnn.graph.operators.elementwise_sum.ElementwiseSum
+   :members:
+
 Elu
 ---
 .. autoclass:: webdnn.graph.operators.elu.Elu
@@ -88,9 +148,29 @@ Embedding
 .. autoclass:: webdnn.graph.operators.embedding.Embedding
    :members:
 
+Exp
+---
+.. autoclass:: webdnn.graph.operators.exp.Exp
+   :members:
+
+Greater
+-------
+.. autoclass:: webdnn.graph.operators.greater.Greater
+   :members:
+
+GreaterEqual
+------------
+.. autoclass:: webdnn.graph.operators.greater_equal.GreaterEqual
+   :members:
+
 HardSigmoid
 -----------
 .. autoclass:: webdnn.graph.operators.hard_sigmoid.HardSigmoid
+   :members:
+
+Im2Col
+------
+.. autoclass:: webdnn.graph.operators.im2col.Im2Col
    :members:
 
 LeakyRelu
@@ -108,6 +188,21 @@ LocalResponseNormalization
 .. autoclass:: webdnn.graph.operators.local_response_normalization.LocalResponseNormalization
    :members:
 
+Log
+---
+.. autoclass:: webdnn.graph.operators.log.Log
+   :members:
+
+LSTM
+----
+.. autoclass:: webdnn.graph.operators.lstm.LSTM
+   :members:
+
+Max
+---
+.. autoclass:: webdnn.graph.operators.max.Max
+   :members:
+
 MaxPooling2D
 ------------
 .. autoclass:: webdnn.graph.operators.max_pooling_2d.MaxPooling2D
@@ -116,6 +211,16 @@ MaxPooling2D
 Pooling2D
 ---------
 .. autoclass:: webdnn.graph.operators.pooling_2d.Pooling2D
+   :members:
+
+Prod
+----
+.. autoclass:: webdnn.graph.operators.prod.Prod
+   :members:
+
+Reduce
+------
+.. autoclass:: webdnn.graph.operators.reduce.Reduce
    :members:
 
 ReinterpretAxis
@@ -131,6 +236,11 @@ Relu
 Reshape
 -------
 .. autoclass:: webdnn.graph.operators.reshape.Reshape
+   :members:
+
+Rsqrt
+-----------
+.. autoclass:: webdnn.graph.operators.rsqrt.Rsqrt
    :members:
 
 ScalarAdd
@@ -153,9 +263,29 @@ ScalarPow
 .. autoclass:: webdnn.graph.operators.scalar_pow.ScalarPow
    :members:
 
+Select
+------
+.. autoclass:: webdnn.graph.operators.select.Select
+   :members:
+
 Sigmoid
 -------
 .. autoclass:: webdnn.graph.operators.sigmoid.Sigmoid
+   :members:
+
+Sin
+---
+.. autoclass:: webdnn.graph.operators.sin.Sin
+   :members:
+
+Sinh
+----
+.. autoclass:: webdnn.graph.operators.sinh.Sinh
+   :members:
+
+Slice
+-----
+.. autoclass:: webdnn.graph.operators.slice.Slice
    :members:
 
 Softmax
@@ -173,14 +303,44 @@ Softsign
 .. autoclass:: webdnn.graph.operators.softsign.Softsign
    :members:
 
+Space2Depth
+-----------
+.. autoclass:: webdnn.graph.operators.space2depth.Space2Depth
+   :members:
+
+Tan
+---
+.. autoclass:: webdnn.graph.operators.tan.Tan
+   :members:
+
 Tanh
 ----
 .. autoclass:: webdnn.graph.operators.tanh.Tanh
    :members:
 
+Tensordot
+---------
+.. autoclass:: webdnn.graph.operators.tensordot.Tensordot
+   :members:
+
 ThresholdRelu
 -------------
 .. autoclass:: webdnn.graph.operators.threshold_relu.ThresholdRelu
+   :members:
+
+Tile
+----
+.. autoclass:: webdnn.graph.operators.tile.Tile
+   :members:
+
+Transpose
+---------
+.. autoclass:: webdnn.graph.operators.transpose.Transpose
+   :members:
+
+Unpooling2D
+-----------
+.. autoclass:: webdnn.graph.operators.unpooling_2d.Unpooling2D
    :members:
 
 ZeroPadding1D

--- a/docs/source/tutorial/caffe.md
+++ b/docs/source/tutorial/caffe.md
@@ -1,4 +1,4 @@
-# Use with caffemodel
+# Use with Caffemodel
 
 In this section, you will learn about how to convert your caffemodel
 into `GraphDescriptor`, and run `GraphDescriptor` on your web page.

--- a/docs/source/tutorial/chainer.rst
+++ b/docs/source/tutorial/chainer.rst
@@ -1,11 +1,11 @@
-Use with chainer model
+Use with Chainer model
 ======================
 
 In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained in Chainer [#f2]_ into WebDNN execution format.
 
 1. Load chainer pretrained model
 
-.. code::
+.. code-block:: python
 
     import chainer
 
@@ -13,7 +13,7 @@ In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained 
 
 2. Execute model with dummy data. In chainer, computation graph are defined by run. Therefore we need execute model at least once to construct the graph.
 
-.. code::
+.. code-block:: python
 
     import numpy as np
 
@@ -22,7 +22,7 @@ In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained 
 
 3. Convert chainer computation graph to our computation graph format
 
-.. code::
+.. code-block:: python
 
     from webdnn.frontend.chainer import ChainerConverter
 
@@ -30,7 +30,7 @@ In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained 
 
 4. Generate and save execution information.
 
-.. code::
+.. code-block:: python
 
     from webdnn.backend import generate_descriptor
 

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -7,7 +7,9 @@ Tutorial
     ./introduction
     ./setup
     ./setup_windows
-    ./keras
     ./caffe
     ./chainer
+    ./keras
+    ./pytorch
+    ./tensorflow
     ./custom_operator/index

--- a/docs/source/tutorial/keras.rst
+++ b/docs/source/tutorial/keras.rst
@@ -1,4 +1,4 @@
-Use with keras model
+Use with Keras model
 ====================
 
 In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained in Keras [#f2]_ into WebDNN execution format.
@@ -6,7 +6,7 @@ In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained 
 1. Export Keras pretrained model
 --------------------------------
 
-.. code::
+.. code-block:: python
 
     from keras.applications import resnet50
     model = resnet50.ResNet50(include_top=True, weights='imagenet')
@@ -15,7 +15,7 @@ In this tutorial, we'll convert ResNet50 [#f1]_ classification model pretrained 
 2. Convert Keras model to our computation graph format
 ------------------------------------------------------
 
-.. code::
+.. code-block:: python
 
     python bin/convert_keras.py resnet50.h5 --input_shape '(1,224,224,3)' --out output
 
@@ -23,7 +23,7 @@ At least you need to specify the model file and the shape of input array.
 
 Also you can convert via python script
 
-.. code::
+.. code-block:: python
 
     from webdnn.frontend.keras import KerasConverter
     from webdnn.backend import generate_descriptor

--- a/docs/source/tutorial/pytorch.rst
+++ b/docs/source/tutorial/pytorch.rst
@@ -1,0 +1,52 @@
+Use with PyTorch model
+======================
+
+In this tutorial, we'll convert AlexNet [#f1]_ pretrained in PyTorch [#f2]_ into WebDNN execution format.
+
+
+.. warning::
+
+    PyTorch convert use :class:`~webdnn.frontend.onnx.ONNXConverter` in conversion. Therefore both :code:`torch` and :code:`onnx`
+    python package are required.
+
+    PyTorch supports onnx export, but currently (12.01.2017), :code:`torch.onnx` module is not included in release build of pytorch.
+    Therefore you have to build pytorch from source.
+    See `https://github.com/pytorch/pytorch#from-source <https://github.com/pytorch/pytorch#from-source>`_.
+
+1. Load PyTorch pretrained model
+
+.. code-block:: python
+
+    import torch, torchvision
+    from webdnn.frontend.pytorch import PyTorchConverter
+
+    model = torchvision.models.alexnet(pretrained=True)
+
+    graph = PyTorchConverter().convert(model, dummy_input)
+
+2. Prepare dummy input to construct computation graph
+
+.. code-block:: python
+
+    dummy_input = torch.autograd.Variable(torch.randn(1, 3, 224, 224))
+
+3. Convert to WebDNN graph
+
+.. code-block:: python
+
+    graph = PyTorchConverter().convert(model, dummy_input)
+
+4. Generate and save execution information.
+
+.. code-block:: python
+
+    from webdnn.backend import generate_descriptor
+
+    exec_info = generate_descriptor("webgpu", graph)  # also "webassembly", "webgl", "fallback" are available.
+    exec_info.save("./output")
+
+To run converted model on web browser, please see :ref:`"#3. Run on web browser" in keras tutorial<js-api>`
+
+.. rubric:: References
+.. [#f1] Krizhevsky, Alex, Ilya Sutskever, and Geoffrey E. Hinton. "ImageNet Classification with Deep Convolutional Neural Networks." Advances in neural information processing systems. 2012.
+.. [#f2] https://pytorch.org

--- a/docs/source/tutorial/tensorflow.rst
+++ b/docs/source/tutorial/tensorflow.rst
@@ -1,0 +1,38 @@
+Use with TensorFlow model
+=========================
+
+In this tutorial, we'll convert model in TensorFlow [#f1]_ into WebDNN execution format.
+
+
+1. Construct TensorFlow computation graph
+
+.. code-block:: python
+
+    import tensorflow as tf
+
+    # y = x @ W + b
+    x = tf.placeholder(tf.float32, [None, 784])
+    W = tf.Variable(tf.zeros([784, 10]))
+    b = tf.Variable(tf.zeros([10]))
+    y = tf.nn.softmax(tf.matmul(x, W) + b)
+
+2. Convert to WebDNN graph
+
+.. code-block:: python
+
+    from webdnn.frontend.tensorflow import TensorFlowConverter
+    graph = TensorFlowConverter().convert([x], [y])
+
+4. Generate and save execution information.
+
+.. code-block:: python
+
+    from webdnn.backend import generate_descriptor
+
+    exec_info = generate_descriptor("webgpu", graph)  # also "webassembly", "webgl", "fallback" are available.
+    exec_info.save("./output")
+
+To run converted model on web browser, please see :ref:`"#3. Run on web browser" in keras tutorial<js-api>`
+
+.. rubric:: References
+.. [#f1] https://www.tensorflow.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -3074,15 +3074,6 @@
                 "readable-stream": "2.3.3"
             }
         },
-        "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3092,6 +3083,15 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {

--- a/src/graph_transpiler/webdnn/backend/code_generator/allocator.py
+++ b/src/graph_transpiler/webdnn/backend/code_generator/allocator.py
@@ -461,8 +461,10 @@ def _optimize_buffer_reuse(allocations_dict: AllocationDict):
                     # del a4s[a2]
 
     console.debug(f"Memory allocation optimization: 100.0% complete.")
-    # Update all allocation offset value
-    list(offset_table.keys())[0].offset = 0
+
+    if len(offset_table) > 0:
+        # Shift allocation block to 0-offset.
+        list(offset_table.keys())[0].offset = 0
 
     for a2, (a1, offset) in merge_tree.items():
         while a1 in merge_tree:

--- a/src/graph_transpiler/webdnn/frontend/__init__.py
+++ b/src/graph_transpiler/webdnn/frontend/__init__.py
@@ -3,6 +3,7 @@
 #
 # webdnn.frontend.chainer
 # webdnn.frontend.keras
+# webdnn.frontend.onnx
 # webdnn.frontend.tensorflow
 #
 

--- a/src/graph_transpiler/webdnn/frontend/chainer/converter.py
+++ b/src/graph_transpiler/webdnn/frontend/chainer/converter.py
@@ -138,7 +138,12 @@ def _listup_functions(inputs: Sequence[T_NODE], outputs: Sequence[T_NODE]):
 
 
 class ChainerConverter(Converter["T_FUNCTION"]):
-    """ChainerConverter()"""
+    """ChainerConverter()
+
+    Converter for `Chainer <https://chainer.org/>`_.
+
+    Currently, from :code:`v1.23` to :code:`v3.1.0` is supported.
+    """
 
     def __init__(self):
         super(ChainerConverter, self).__init__()
@@ -160,18 +165,6 @@ class ChainerConverter(Converter["T_FUNCTION"]):
             This method will be removed in the future version. Use :func:`~webdnn.frontend.chainer.ChainerConverter.convert(inputs,
             outputs)`.
 
-        .. admonition:: Example
-
-            .. code::
-
-                model = chainer.links.model.vision.resnet.ResNet50Layers()
-
-                # Forward propagation with dummy input to build computational graph
-                x = chainer.Variable(np.empty((1, 3, 224, 224), dtype=np.float32))
-                y = model(x, layers=["fc6"])["fc6"]
-
-                graph = ChainerConverter().convert_from_inout_vars([x], [y])
-
         Returns:
             (:class:`~webdnn.Graph`): WebDNN Graph
         """
@@ -188,7 +181,9 @@ class ChainerConverter(Converter["T_FUNCTION"]):
             inputs(list of chainer.Variable): input chainer variables
             outputs(list of chainer.Variable): output chainer variables
 
-        .. admonition:: Example
+        .. admonition:: example
+
+            Convert pre-trained ResNet model
 
             .. code::
 
@@ -198,7 +193,7 @@ class ChainerConverter(Converter["T_FUNCTION"]):
                 x = chainer.Variable(np.empty((1, 3, 224, 224), dtype=np.float32))
                 y = model(x, layers=["fc6"])["fc6"]
 
-                graph = ChainerConverter().convert_from_inout_vars([x], [y])
+                graph = ChainerConverter().convert([x], [y])
 
         Returns:
             (:class:`~webdnn.Graph`): WebDNN Graph

--- a/src/graph_transpiler/webdnn/frontend/chainer/functions/noise.py
+++ b/src/graph_transpiler/webdnn/frontend/chainer/functions/noise.py
@@ -6,7 +6,7 @@ from webdnn.util import console
 
 @ChainerConverter.register_handler("Dropout")
 def _convert_dropout(converter: ChainerConverter, c_op: "chainer.functions.Dropout"):
-    console.warning("Dropout is omitted")
+    console.warning("[ChainerConverter] Dropout is ignored")
 
     x = converter.get_variable(c_op.inputs[0])
 

--- a/src/graph_transpiler/webdnn/frontend/keras/converter.py
+++ b/src/graph_transpiler/webdnn/frontend/keras/converter.py
@@ -37,7 +37,7 @@ def _to_list(x):
 class KerasConverter(Converter["keras.layers.Layer"]):
     """KerasConverter(batch_size=1)
 
-    Convert keras.models.model into WebDNN IR.
+    Converter for `Keras <https://keras.io/>`_.
 
     **Limitations**
 
@@ -81,10 +81,17 @@ class KerasConverter(Converter["keras.layers.Layer"]):
         Args:
             model (`keras.models.Model`): keras model
 
-        .. example::
+        .. admonition:: example
 
-            model = keras.models.load_model("pre_trained_model.h5")
-            graph = KerasConverter(batch_size=1).convert(model)
+            Convert pre-trained keras ResNet model.
+
+            .. code::
+
+                import keras
+                from webdnn.frontend.keras import KerasConverter
+
+                model = keras.applications.resnet50.ResNet50(include_top=True, weights='imagenet')
+                graph = KerasConverter(batch_size=1).convert(model)
 
         Returns:
             (:class:`~webdnn.graph.graph.Graph`): WebDNN IR Graph

--- a/src/graph_transpiler/webdnn/frontend/onnx/README.md
+++ b/src/graph_transpiler/webdnn/frontend/onnx/README.md
@@ -1,0 +1,51 @@
+# ONNX frontend
+
+WebDNN Converter Frontend for [Open Neural Network Exchange (ONNX) format](http://onnx.ai/).
+
+## Setup
+
+### ONNX
+
+If you use anaconda, it completes by just one command.
+
+```bash
+conda install -c ezyang onnx
+```
+
+In other case, see [onnx's github repository(https://github.com/onnx/onnx)](https://github.com/onnx/onnx).
+
+You can verify it was installed correctly with the following command.
+
+```bash
+python -c "import onnx"
+```
+
+### PyTorch
+
+PyTorch supports onnx, but currently (11.09.2017), `torch.onnx` module is not included in release build of pytorch. 
+You have to build torch from source. See [https://github.com/pytorch/pytorch#from-source](https://github.com/pytorch/pytorch#from-source).
+
+
+## Example
+
+```python
+"""
+This code is based on http://pytorch.org/docs/master/onnx.html
+"""
+from torch.autograd import Variable
+import torch.onnx
+import torchvision
+import onnx
+from webdnn.frontend.onnx import ONNXConverter
+
+# export PyTorch's AlexNet model
+dummy_input = Variable(torch.randn(1, 3, 224, 224))
+model = torchvision.models.alexnet(pretrained=True)
+torch.onnx.export(model, dummy_input, "alexnet.proto", verbose=True)
+
+# import model in onnx
+model = onnx.load("alexnet.proto")
+
+# convert
+graph = ONNXConverter().convert(model)
+```

--- a/src/graph_transpiler/webdnn/frontend/onnx/__init__.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/__init__.py
@@ -1,0 +1,4 @@
+from webdnn.frontend.onnx import converter
+from webdnn.frontend.onnx import defs
+# alias
+from webdnn.frontend.onnx.converter import ONNXConverter

--- a/src/graph_transpiler/webdnn/frontend/onnx/converter.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/converter.py
@@ -1,0 +1,187 @@
+"""
+ONNX (https://github.com/onnx) Frontend
+"""
+from typing import Set, List, Union, Dict
+
+from webdnn.frontend.converter import Converter
+from webdnn.frontend.onnx.type_hint import *
+from webdnn.graph.graph import Graph
+from webdnn.graph.order import Order
+from webdnn.graph.variable import Variable
+from webdnn.graph.variables.attributes.input import Input
+from webdnn.graph.variables.attributes.output import Output
+from webdnn.graph.variables.constant_variable import ConstantVariable
+from webdnn.util import console
+
+FLAG_ONNX_INSTALLED = False
+try:
+    import onnx
+
+    FLAG_ONNX_INSTALLED = True
+
+except ImportError as e:
+    console.debug("ONNX is not completely installed.")
+    pass
+
+
+def attribute_dict(proto: INodeProto) -> Dict[str, IAttributeProto]:
+    return {attr.name: attr for attr in proto.attribute}
+
+
+class ONNXConverter(Converter["onnx.NodeProto"]):
+    """ONNXConverter()
+
+    Converter for `Open Neural Network Exchange (ONNX) <http://onnx.ai/>`_.
+
+    To use this converter, you need to install ONNX python module. see `ONNX github repository <https://github.com/onnx/onnx>`_.
+    """
+
+    def __init__(self):
+        super(ONNXConverter, self).__init__()
+        if not FLAG_ONNX_INSTALLED:
+            raise ImportError("""
+Module "onnx" cannot be imported. Please check that follow command works correctly.
+    
+    python -c "import onnx"
+
+""")
+
+    def serialize_operator_type(self, proto: INodeProto):
+        return proto.op_type
+
+    def convert(self, model: IModelProto) -> Graph:
+        """convert(model)
+
+        Convert ONNX computational graph into WebDNN IR.
+
+        Args:
+            model: Proto data of ONNX model
+
+        .. admonition:: example
+
+            Convert model stored as ONNX format in "model.proto".
+
+            .. code::
+
+                import onnx
+                from webdnn.frontend.onnx import ONNXConverter
+
+                # import model in onnx
+                model = onnx.load("model.proto")
+
+                # convert
+                graph = ONNXConverter().convert(model)
+
+        Returns:
+            (:class:`~webdnn.Graph`): WebDNN Graph
+        """
+        graph = model.graph  # type: IGraphProto
+
+        # Convert constant parameters
+        for proto in graph.initializer:
+            self.set_variable(proto.name, _convert_tensor_proto(proto))
+
+        # Convert input variables
+        # In ONNX, both input variable and parameters are included in `graph.input`.
+        inputs = []
+        for proto in filter(lambda proto: not self.has_variable(proto.name), graph.input):
+            v = _convert_value_info_proto(proto)
+            self.set_variable(proto.name, v)
+            inputs.append(v)
+
+        # Convert operators
+        for onnx_op in _listup_functions(graph):
+            self._convert_operator(onnx_op)
+
+        graph = Graph(inputs, [self.get_variable(proto.name) for proto in graph.output])
+
+        for v in graph.inputs:
+            v.attributes.add(Input(v))
+
+        for v in graph.outputs:
+            v.attributes.add(Output(v))
+
+        return graph
+
+    def _convert_operator(self, proto: INodeProto):
+        console.debug(f"-----------------------------------------------------------")
+        console.debug(f"Type  : {proto.op_type}")
+        console.debug(f"Input : {proto.input}")
+        console.debug(f"Output: {proto.output}")
+        for name, val in attribute_dict(proto).items():
+            console.debug(f"Attr  : {name} = {val}")
+
+        super(ONNXConverter, self)._convert_operator(proto)
+
+
+def _convert_tensor_proto(proto: ITensorProto) -> ConstantVariable:
+    """
+    Convert TensorProto into constant variable.
+    """
+    np_type = DataTypeMappingDict[proto.data_type]
+    if np_type.type is None:
+        raise TypeError(f"[ONNXConverter] type \"{np_type.name}\" is not supported")
+
+    data = np.frombuffer(proto.raw_data, np_type.type).reshape([1] if len(proto.dims) == 0 else proto.dims)
+    return ConstantVariable(data, Order([None] * data.ndim))
+
+
+def _convert_value_info_proto(proto: IValueInfoProto) -> Variable:
+    """
+    Convert ValueInfoProto into variable.
+    """
+    shape = [1] if len(proto.type.tensor_type.shape.dim) == 0 else [d.dim_value for d in proto.type.tensor_type.shape.dim]
+    return Variable(shape, Order([None] * len(shape)))
+
+
+def _listup_functions(graph: IGraphProto) -> Sequence[INodeProto]:
+    _counter = 0
+
+    class Container:
+        """
+        Proto object is not hashable. this container supports hash operation with proto object.
+        """
+
+        def __init__(self, proto: INodeProto):
+            nonlocal _counter
+            self.proto = proto
+            self._hash = id(_counter)
+            _counter += 1
+
+        def __hash__(self):
+            return self._hash
+
+    stack = [proto.name for proto in graph.output]  # type: List[Union[Container, str]]
+    resolved = {proto.name for proto in graph.input}  # type: Set[Union[Container, str]]
+    result = []  # type: List[INodeProto]
+
+    creator_map = {}
+    for proto in graph.node:
+        for name in proto.output:
+            creator_map[name] = Container(proto)
+
+    while len(stack) > 0:
+        node = stack.pop()
+        if node in resolved:
+            continue
+
+        if isinstance(node, str):
+            # node is tensor's name
+            prev_nodes = [] if node not in creator_map else [creator_map[node]]
+
+        else:
+            # node is container of operator proto
+            prev_nodes = list(node.proto.input)
+
+        unresolved_prevs = [prev_node for prev_node in prev_nodes if prev_node not in resolved]
+
+        if len(unresolved_prevs) == 0:
+            resolved.add(node)
+            if not isinstance(node, str):
+                result.append(node.proto)
+
+        else:
+            stack.append(node)
+            stack += unresolved_prevs
+
+    return result

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/__init__.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/__init__.py
@@ -1,0 +1,7 @@
+from webdnn.frontend.onnx.defs import generator
+from webdnn.frontend.onnx.defs import logical
+from webdnn.frontend.onnx.defs import math
+from webdnn.frontend.onnx.defs import nn
+from webdnn.frontend.onnx.defs import reduction
+from webdnn.frontend.onnx.defs import rnn
+from webdnn.frontend.onnx.defs import tensor

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/generator.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/generator.py
@@ -1,0 +1,41 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/generator/defs.cc
+"""
+from webdnn.frontend.onnx.converter import ONNXConverter, attribute_dict
+from webdnn.frontend.onnx.type_hint import *
+from webdnn.graph.order import Order
+from webdnn.graph.variables.constant_variable import ConstantVariable
+
+
+@ONNXConverter.register_handler("Constant")
+def _convert_constant(converter: ONNXConverter, onnx_op: INodeProto):
+    attrs = attribute_dict(onnx_op)
+    value = attrs["value"].t
+
+    np_type = DataTypeMappingDict[value.data_type]
+    if np_type.type is None:
+        raise TypeError(f"[ONNXConverter] type \"{np_type.name}\" is not supported")
+    data = np.frombuffer(value.raw_data, np_type.type).reshape([1] if len(value.dims) == 0 else value.dims)
+
+    y = ConstantVariable(data, Order([None] * data.ndim))
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("RandomUniform")
+def _convert_random_uniform(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"RandomUniform\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("RandomNormal")
+def _convert_random_normal(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"RandomNormal\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("RandomUniformLike")
+def _convert_random_uniform_like(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"RandomUniformLike\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("RandomNormalLike")
+def _convert_random_normal_like(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"RandomNormalLike\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/logical.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/logical.py
@@ -1,0 +1,3 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/logical/defs.cc
+"""

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/math.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/math.py
@@ -1,0 +1,282 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/math/defs.cc
+"""
+
+from webdnn.frontend.onnx.converter import ONNXConverter, attribute_dict
+from webdnn.frontend.onnx.defs.util import check_broadcast_constraints
+from webdnn.frontend.onnx.type_hint import INodeProto
+from webdnn.graph.operators.elu import Elu
+from webdnn.graph.operators.exp import Exp
+from webdnn.graph.operators.leaky_relu import LeakyRelu
+from webdnn.graph.operators.log import Log
+from webdnn.graph.operators.relu import Relu
+from webdnn.graph.operators.sigmoid import Sigmoid
+from webdnn.graph.operators.softmax import Softmax
+from webdnn.graph.operators.tanh import Tanh
+from webdnn.graph.operators.tensordot import Tensordot
+
+
+@ONNXConverter.register_handler("Add")
+def _convert_add(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    x1 = converter.get_variable(onnx_op.input[1])
+
+    attrs = attribute_dict(onnx_op)
+
+    if "broadcast" in attrs:
+        broadcast = attrs["broadcast"].i
+        if broadcast:
+            check_broadcast_constraints(x0, x1, axis=attrs["axis"].i if "axis" in attrs else None)
+
+        else:
+            x0.order.unify(x1.order)
+    else:
+        x0.order.unify(x1.order)
+
+    y = x0 + x1
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Sub")
+def _convert_sub(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    x1 = converter.get_variable(onnx_op.input[1])
+
+    attrs = attribute_dict(onnx_op)
+
+    if "broadcast" in attrs:
+        broadcast = attrs["broadcast"].i
+        if broadcast:
+            check_broadcast_constraints(x0, x1, axis=attrs["axis"].i if "axis" in attrs else None)
+
+        else:
+            x0.order.unify(x1.order)
+    else:
+        x0.order.unify(x1.order)
+
+    y = x0 - x1
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Mul")
+def _convert_mul(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    x1 = converter.get_variable(onnx_op.input[1])
+
+    attrs = attribute_dict(onnx_op)
+
+    if "broadcast" in attrs:
+        broadcast = attrs["broadcast"].i
+        if broadcast:
+            check_broadcast_constraints(x0, x1, axis=attrs["axis"].i if "axis" in attrs else None)
+
+        else:
+            x0.order.unify(x1.order)
+    else:
+        x0.order.unify(x1.order)
+
+    y = x0 * x1
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Div")
+def _convert_div(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    x1 = converter.get_variable(onnx_op.input[1])
+
+    attrs = attribute_dict(onnx_op)
+
+    if "broadcast" in attrs:
+        broadcast = attrs["broadcast"].i
+        if broadcast:
+            check_broadcast_constraints(x0, x1, axis=attrs["axis"].i if "axis" in attrs else None)
+
+        else:
+            x0.order.unify(x1.order)
+    else:
+        x0.order.unify(x1.order)
+
+    y = x0 / x1
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Neg")
+def _convert_neg(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y = -x0
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Abs")
+def _convert_abs(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y = abs(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Reciprocal")
+def _convert_reciprocal(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y = 1 / x0
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Floor")
+def _convert_floor(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's easy to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] \"Floor\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Ceil")
+def _convert_ceil(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's easy to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Ceil\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Sqrt")
+def _convert_sqrt(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's easy to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Sqrt\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Relu")
+def _convert_relu(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+
+    y, = Relu(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("LeakyRelu")
+def _convert_leaky_relu(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+
+    attrs = attribute_dict(onnx_op)
+    alpha = attrs["alpha"].f
+
+    y, = LeakyRelu(None, slope=alpha)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Selu")
+def _convert_selu(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"Selu\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Elu")
+def _convert_elu(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+
+    attrs = attribute_dict(onnx_op)
+    alpha = attrs["alpha"].f
+    if alpha != 1:
+        raise NotImplementedError("[ONNXConverter] Operator \"Elu\" is supported only the case when parameter \"alpha\" is 1.")
+
+    y, = Elu(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Exp")
+def _convert_exp(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y, = Exp(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Log")
+def _convert_log(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y, = Log(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Tanh")
+def _convert_tanh(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y, = Tanh(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Pow")
+def _convert_pow(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    x1 = converter.get_variable(onnx_op.input[1])
+
+    check_broadcast_constraints(x0, x1)
+
+    y = x0 ** x1
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("PRelu")
+def _convert_prelu(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"PRelu\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Sigmoid")
+def _convert_sigmoid(converter: ONNXConverter, onnx_op: INodeProto):
+    x0 = converter.get_variable(onnx_op.input[0])
+    y, = Sigmoid(None)(x0)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Max")
+def _convert_max(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"Max\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Min")
+def _convert_min(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"Min\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Sum")
+def _convert_sum(converter: ONNXConverter, onnx_op: INodeProto):
+    xs = [converter.get_variable(proto) for proto in onnx_op.input]
+
+    while len(xs) > 1:
+        check_broadcast_constraints(xs[0], xs[1])
+        xs.append(xs.pop(0) + xs.pop(0))
+
+    converter.set_variable(onnx_op.output[0], xs[0])
+
+
+@ONNXConverter.register_handler("Softmax")
+def _convert_softmax(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+
+    attrs = attribute_dict(onnx_op)
+    axis = attrs["axis"].i
+
+    y, = Softmax(None, axis=x.order.axes[axis])(x)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Gemm")
+def _convert_gemm(converter: ONNXConverter, onnx_op: INodeProto):
+    A = converter.get_variable(onnx_op.input[0])
+    B = converter.get_variable(onnx_op.input[1])
+    C = converter.get_variable(onnx_op.input[2])
+
+    attrs = attribute_dict(onnx_op)
+    alpha = attrs["alpha"].f
+    beta = attrs["beta"].f
+    broadcast = attrs.get("broadcast", 0)
+
+    y, = Tensordot(None, axes=(A.order.axes[0 if attrs["transA"].i else 1], B.order.axes[1 if attrs["transB"].i else 0]))(A, B)
+
+    if broadcast:
+        check_broadcast_constraints(y, C)
+    else:
+        y.order.unify(C.order)
+
+    y = alpha * y + beta * C
+
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("MatMul")
+def _convert_matmul(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"MatMul\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/nn.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/nn.py
@@ -1,0 +1,142 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/nn/defs.cc
+"""
+from webdnn.graph.axis import Axis
+from webdnn.frontend.onnx.converter import ONNXConverter, attribute_dict
+from webdnn.frontend.onnx.type_hint import INodeProto
+from webdnn.graph.operators.average_pooling_2d import AveragePooling2D
+from webdnn.graph.operators.convolution2d import Convolution2D
+from webdnn.graph.operators.max_pooling_2d import MaxPooling2D
+from webdnn.graph.order import OrderC, OrderNCHW, Order
+from webdnn.util import console
+
+
+@ONNXConverter.register_handler("AveragePool")
+def _convert_average_pool(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+    x.order.unify(OrderNCHW)
+
+    attrs = attribute_dict(onnx_op)
+    ksize = list(attrs["kernel_shape"].ints)
+    dilations = list(attrs["dilations"].ints)
+    if any(d != 1 for d in dilations):
+        raise NotImplementedError("[ONNXConverter] AveragePool is supported only when dilations are 1.")
+
+    stride = list(attrs["strides"].ints)
+
+    pad = list(attrs["pads"].ints)
+    if len(pad) == 2:
+        # NOTE:
+        # In PyTorch, pads is generated as tuple of 2 integers, but ONNX spec says that pads contains 2*N integers where N is the number of
+        # padded dimension. It's maybe PyTorch's bug.
+        pass
+
+    else:
+        if any(pad[2 * i] != pad[2 * i + 1] for i in range(len(pad) // 2)):
+            raise NotImplementedError("[ONNXConverter] odd-size padding is not supported.")
+        pad = [pad[0], pad[2]]
+
+    y, = AveragePooling2D(None, ksize=ksize, stride=stride, padding=pad)(x)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("MaxPool")
+def _convert_max_pool(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+    x.order.unify(OrderNCHW)
+
+    attrs = attribute_dict(onnx_op)
+    ksize = list(attrs["kernel_shape"].ints)
+    dilations = list(attrs["dilations"].ints)
+    if any(d != 1 for d in dilations):
+        raise NotImplementedError("[ONNXConverter] MaxPool is supported only when dilations are 1.")
+
+    stride = list(attrs["strides"].ints)
+
+    pad = list(attrs["pads"].ints)
+    if len(pad) == 2:
+        # NOTE:
+        # In PyTorch, pads is generated as tuple of 2 integers, but ONNX spec says that pads contains 2*N integers where N is the number of
+        # padded dimension. It's maybe PyTorch's bug.
+        pass
+
+    else:
+        if any(pad[2 * i] != pad[2 * i + 1] for i in range(len(pad) // 2)):
+            raise NotImplementedError("[ONNXConverter] odd-size padding is not supported.")
+        pad = [pad[0], pad[2]]
+
+    y, = MaxPooling2D(None, ksize=ksize, stride=stride, padding=pad)(x)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Conv")
+def _convert_conv(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+    x.order.unify(OrderNCHW)
+
+    w = converter.get_variable(onnx_op.input[1])
+    w.order.unify(Order([Axis.N, Axis.C, Axis.KH, Axis.KW]))
+
+    attrs = attribute_dict(onnx_op)
+    ksize = list(attrs["kernel_shape"].ints)
+    dilations = list(attrs["dilations"].ints)
+    stride = list(attrs["strides"].ints)
+
+    pad = list(attrs["pads"].ints)
+    if any(pad[2 * i] != pad[2 * i + 1] for i in range(len(pad) // 2)):
+        raise NotImplementedError("[ONNXConverter] odd-size padding is not supported.")
+    pad = [pad[0], pad[2]]
+
+    y, = Convolution2D(None, ksize=ksize, stride=stride, padding=pad, dilation_rate=dilations)(x, w)
+    y.change_order(OrderNCHW)
+
+    if len(onnx_op.input) == 3:
+        # with bias
+        b = converter.get_variable(onnx_op.input[2])
+        b.order.unify(OrderC)
+        y = y + b
+
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("ConvTranspose")
+def _convert_conv_transpose(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ConvTranspose\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("GlobalAveragePool")
+def _convert_global_average_pool(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"GlobalAveragePooling\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("GlobalMaxPool")
+def _convert_global_max_pool(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"GlobalMaxPool\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("BatchNormalization")
+def _convert_batch_normalization(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"BatchNormalization\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Dropout")
+def _convert_max_pool(converter: ONNXConverter, onnx_op: INodeProto):
+    console.warning("[ONNXConverter] Operator \"Dropout\" is ignored")
+    x = converter.get_variable(onnx_op.input[0])
+    converter.set_variable(onnx_op.output[0], x)
+
+
+@ONNXConverter.register_handler("Flatten")
+def _convert_flatten(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Flatten\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("LRN")
+def _convert_lrn(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"LRN\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/reduction.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/reduction.py
@@ -1,0 +1,54 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/reduction/defs.cc
+"""
+
+from webdnn.frontend.onnx.converter import ONNXConverter
+from webdnn.frontend.onnx.type_hint import INodeProto
+
+
+@ONNXConverter.register_handler("ReduceMax")
+def _convert_reduce_max(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceMax\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ReduceMin")
+def _convert_reduce_min(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceMin\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ReduceSum")
+def _convert_reduce_sum(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceSum\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ReduceMean")
+def _convert_reduce_mean(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceMean\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ReduceProd")
+def _convert_reduce_prod(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceProd\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ReduceLogSumExp")
+def _convert_reduce_logsumexp(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's easy to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ReduceLogSumExp\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ArgMax")
+def _convert_argmax(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ArgMax\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("ArgMin")
+def _convert_argmin(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"ArgMin\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/rnn.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/rnn.py
@@ -1,0 +1,24 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/rnn/defs.cc
+"""
+
+from webdnn.frontend.onnx.converter import ONNXConverter
+from webdnn.frontend.onnx.type_hint import INodeProto
+
+
+@ONNXConverter.register_handler("RNN")
+def _convert_rnn(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"RNN\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("GRU")
+def _convert_random_gru(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"GRU\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("LSTM")
+def _convert_lstm(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"LSTM\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/tensor.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/tensor.py
@@ -1,0 +1,81 @@
+"""
+https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/defs/tensor/defs.cc
+"""
+
+from webdnn.frontend.onnx.converter import ONNXConverter, attribute_dict
+from webdnn.frontend.onnx.type_hint import INodeProto
+from webdnn.graph.operators.reshape import Reshape
+from webdnn.graph.operators.transpose import Transpose
+from webdnn.graph.order import Order
+from webdnn.util import console
+from webdnn.util.misc import mul
+
+
+@ONNXConverter.register_handler("Cast")
+def _convert_cast(converter: ONNXConverter, onnx_op: INodeProto):
+    console.warning("[ONNXConverter] Operator \"Cast\" is ignored")
+    x = converter.get_variable(onnx_op.input[0])
+    converter.set_variable(onnx_op.output[0], x)
+
+
+@ONNXConverter.register_handler("Reshape")
+def _convert_reshape(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+    attrs = attribute_dict(onnx_op)
+    out_shape = [r if s == 0 else s for r, s in zip(x.shape, attrs["shape"].ints)]
+
+    if -1 in out_shape:
+        i = out_shape.index(-1)
+        out_shape.remove(-1)
+        out_shape.insert(i, x.size // mul(out_shape))
+
+    out_order = Order([None] * len(out_shape))
+
+    y, = Reshape(None, in_order=x.order, out_order=out_order, out_shape=out_shape)(x)
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Concat")
+def _convert_concat(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Concat\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Split")
+def _convert_split(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Split\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Slice")
+def _convert_slice(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"Slice\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Transpose")
+def _convert_transpose(converter: ONNXConverter, onnx_op: INodeProto):
+    x = converter.get_variable(onnx_op.input[0])
+    attrs = attribute_dict(onnx_op)
+
+    y, = Transpose(None)(x)
+    perm = list(attrs["perm"].ints if "perm" in attrs else reversed(range(x.ndim)))
+    y.change_order(Order([x.order.axes[i] for i in perm]))
+
+    converter.set_variable(onnx_op.output[0], y)
+
+
+@ONNXConverter.register_handler("Gather")
+def _convert_gather(converter: ONNXConverter, onnx_op: INodeProto):
+    raise NotImplementedError("[ONNXConverter] Operator \"Gather\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Squeeze")
+def _convert_squeeze(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Squeeze\" is not supported yet.")
+
+
+@ONNXConverter.register_handler("Pad")
+def _convert_pad(converter: ONNXConverter, onnx_op: INodeProto):
+    # FIXME: It's possible to support in current version of webdnn
+    raise NotImplementedError("[ONNXConverter] Operator \"Pad\" is not supported yet.")

--- a/src/graph_transpiler/webdnn/frontend/onnx/defs/util.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/defs/util.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+from webdnn.graph.axis import Axis
+from webdnn.graph.variable import Variable
+
+
+def check_broadcast_constraints(a: Variable, b: Variable, axis: Optional[int] = None):
+    """check_broadcast_constraints(a, b, axis=None)
+
+    Check follow constraints corresponding to broadcasting:
+
+        - each axes pair must be same axis.
+        - shape must be valid for broadcasting.
+
+    Args:
+        a, b: Variable
+        axis: broadcast start position
+
+            a.shape=(2, 3, 4, 5) b.shape=(5),     --> If axis=3 (or None), broadcasting is possible.
+            a.shape=(2, 3, 4, 5) b.shape=(3, 4),  --> If axis=1, broadcasting is possible.
+
+        Note that `axis=None` (or `a.ndim - b.ndim`) is same as numpy-style broadcasting.
+
+    Returns:
+
+    """
+    a_shape = list(a.shape)
+    b_shape = list(b.shape)
+    a_axes = list(a.order.axes)
+    b_axes = list(b.order.axes)
+    a_ndim = a.ndim
+    b_ndim = b.ndim
+
+    if axis is None:
+        axis = a_ndim - b_ndim
+
+    for _ in range(axis):
+        b_shape = [1] + b_shape
+        b_axes = [Axis()] + b_axes
+        b_ndim += 1
+
+    while a_ndim < b_ndim:
+        a_shape = a_shape + [1]
+        a_axes = a_axes + [Axis()]
+        a_ndim += 1
+
+    while b_ndim < a_ndim:
+        b_shape = b_shape + [1]
+        b_axes = b_axes + [Axis()]
+        b_ndim += 1
+
+    for i in range(a_ndim):
+        if a_shape[i] == b_shape[i] or a_shape[i] == 1 or b_shape[i] == 1:
+            a_axes[i].unify(b_axes[i])
+
+            if (a_shape[i] == 1 and b_shape[i] == 1) or (a_shape[i] != 1 and b_shape[i] != 1):
+                # If broadcast is not occurred, size must be same
+                assert a_shape[i] == b_shape[i], f"""
+Shape mismatch: a.shape[{i}] != b.shape[{i}]
+  (a.shape) = {a_shape}
+  (b.shape) = {b_shape}
+"""
+
+        else:
+            raise ValueError(f"""Broadcast is failed: \n
+  (a.shape)={a_shape}
+  (b.shape)={b_shape}
+  (axis)={axis}""")

--- a/src/graph_transpiler/webdnn/frontend/onnx/type_hint.py
+++ b/src/graph_transpiler/webdnn/frontend/onnx/type_hint.py
@@ -1,0 +1,155 @@
+"""
+Type declaration for ONNX protocol buffer definition
+Because python type hinting cannot recognized protobuf type definition, so this declaration is useful.
+
+This declaration is based on https://github.com/onnx/onnx/blob/09ada0f107f1cc1877f9194475c98d2d8512e188/onnx/onnx.proto
+"""
+
+from typing import NamedTuple, Sequence, Type, Optional
+
+import numpy as np
+
+
+# `typing.Sequence` can be regarded as subset of `google.protobuf.pyext._message.RepeatedCompositeContainer` (repeated field of `Message`)
+
+class IAttributeProto(NamedTuple):
+    name: str
+    type: int
+
+    # Exactly ONE of the following fields must be present for this version of the ONNX IR
+    f: float
+    i: int
+    s: bytes
+    t: "ITensorProto"
+    g: "IGraphProto"
+
+    floats: Sequence[float]
+    ints: Sequence[int]
+    strings: bytes
+    tensors: Sequence["ITensorProto"]
+    graphs: Sequence["IGraphProto"]
+
+    pass
+
+
+class INodeProto(NamedTuple):
+    input: Sequence[str]
+    output: Sequence[str]
+    name: str
+    op_type: str
+    attribute: Sequence[IAttributeProto]
+
+
+class IDimensionProto(NamedTuple):
+    dim_value: int
+
+
+class ITensorShapeProto(NamedTuple):
+    dim: Sequence[IDimensionProto]
+
+
+class ITensorTypeProto(NamedTuple):
+    shape: ITensorShapeProto
+
+
+class ITypeProto(NamedTuple):
+    tensor_type: ITensorTypeProto
+
+
+class IValueInfoProto(NamedTuple):
+    name: str
+    type: ITypeProto
+
+
+class ITensorProto(NamedTuple):
+    name: str
+    data_type: int
+    dims: Sequence[int]
+    raw_data: bytes
+
+
+class IGraphProto(NamedTuple):
+    initializer: Sequence[ITensorProto]
+    input: Sequence[IValueInfoProto]
+    node: Sequence[INodeProto]
+    output: Sequence[IValueInfoProto]
+
+
+class IModelProto(NamedTuple):
+    graph: IGraphProto
+
+
+class AttributeType:
+    UNDEFINED = 0
+    FLOAT = 1
+    INT = 2
+    STRING = 3
+    TENSOR = 4
+    GRAPH = 5
+
+    FLOATS = 6
+    INTS = 7
+    STRINGS = 8
+    TENSORS = 9
+    GRAPHS = 10
+
+
+AttributeTypeMappingDict = {
+    AttributeType.FLOAT: "f",
+    AttributeType.INT: "i",
+    AttributeType.STRING: "s",
+    AttributeType.TENSOR: "t",
+    AttributeType.GRAPH: "g",
+
+    AttributeType.FLOATS: "floats",
+    AttributeType.INTS: "ints",
+    AttributeType.STRINGS: "strings",
+    AttributeType.TENSORS: "tensors",
+    AttributeType.GRAPHS: "graphs",
+}
+
+
+class DataType:
+    UNDEFINED = 0
+    FLOAT = 1
+    UINT8 = 2
+    INT8 = 3
+    UINT16 = 4
+    INT16 = 5
+    INT32 = 6
+    INT64 = 7
+    STRING = 8
+    BOOL = 9
+
+    FLOAT16 = 10
+    DOUBLE = 11
+    UINT32 = 12
+    UINT64 = 13
+    COMPLEX64 = 14
+    COMPLEX128 = 15
+
+
+class NumPyDataType(NamedTuple):
+    name: str
+    type: Optional[Type]
+
+
+DataTypeMappingDict = {
+    DataType.UNDEFINED: NumPyDataType("", None),
+    DataType.FLOAT: NumPyDataType("FLOAT", np.float32),
+    DataType.UINT8: NumPyDataType("UINT8", np.uint8),
+    DataType.INT8: NumPyDataType("INT8", np.int8),
+    DataType.UINT16: NumPyDataType("UINT16", np.uint16),
+    DataType.INT16: NumPyDataType("INT16", np.int16),
+    DataType.INT32: NumPyDataType("INT32", np.int32),
+    DataType.INT64: NumPyDataType("INT64", None),
+    DataType.STRING: NumPyDataType("STRING", None),
+    DataType.BOOL: NumPyDataType("BOOL", None),
+
+    DataType.FLOAT16: NumPyDataType("FLOAT16", np.float16),
+    DataType.DOUBLE: NumPyDataType("DOUBLE", None),
+    DataType.UINT32: NumPyDataType("UINT32", np.uint32),
+    DataType.UINT64: NumPyDataType("UINT64", np.uint64),
+    DataType.COMPLEX64: NumPyDataType("COMPLEX64", None),
+    DataType.COMPLEX128: NumPyDataType("COMPLEX128", None),
+}

--- a/src/graph_transpiler/webdnn/frontend/pytorch/README.md
+++ b/src/graph_transpiler/webdnn/frontend/pytorch/README.md
@@ -1,0 +1,20 @@
+# PyTorch frontend
+
+WebDNN Converter Frontend for PyTorch.
+
+This converter convert PyTorch model through [ONNX](http://onnx.ai/) format.
+
+PyTorch supports onnx, but currently (12.01.2017), `torch.onnx` module is not included in release build of pytorch. 
+You have to build torch from source. See [https://github.com/pytorch/pytorch#from-source](https://github.com/pytorch/pytorch#from-source).
+
+## Example
+
+```python
+import torch, torchvision
+from webdnn.frontend.pytorch import PyTorchConverter
+
+model = torchvision.models.alexnet(pretrained=True)
+dummy_input = torch.autograd.Variable(torch.randn(1, 3, 224, 224))
+
+graph = PyTorchConverter().convert(model, dummy_input)
+```

--- a/src/graph_transpiler/webdnn/frontend/pytorch/__init__.py
+++ b/src/graph_transpiler/webdnn/frontend/pytorch/__init__.py
@@ -1,0 +1,3 @@
+from webdnn.frontend.pytorch import converter
+# alias
+from webdnn.frontend.pytorch.converter import PyTorchConverter

--- a/src/graph_transpiler/webdnn/frontend/pytorch/converter.py
+++ b/src/graph_transpiler/webdnn/frontend/pytorch/converter.py
@@ -1,0 +1,96 @@
+"""
+PyTorch Frontend
+"""
+import tempfile
+from os import path
+
+from webdnn.frontend.converter import Converter
+from webdnn.frontend.onnx import ONNXConverter
+from webdnn.graph.graph import Graph
+from webdnn.util import console
+
+FLAG_PYTORCH_INSTALLED = False
+try:
+    import torch
+    import torch.onnx
+
+    FLAG_PYTORCH_INSTALLED = True
+
+except ImportError as e:
+    console.debug("PyTorch is not completely installed.")
+    pass
+
+FLAG_ONNX_INSTALLED = False
+try:
+    import onnx
+
+    FLAG_ONNX_INSTALLED = True
+
+except ImportError as e:
+    console.debug("ONNX is not completely installed.")
+    pass
+
+
+class PyTorchConverter(Converter["torch.nn.Module"]):
+    """PyTorchConverter()
+
+    Converter for `PyTorch <http://pytorch.org/>`_.
+
+    In conversion, model is exported as ONNX format, and then converted by :class:`~webdnn.frontend.onnx.ONNXConverter`.
+    Therefore both torch and onnx python package are required.
+
+    .. warning::
+
+        PyTorch supports onnx export, but currently (12.01.2017), :code:`torch.onnx` module is not included in release build of pytorch.
+        Therefore you have to build pytorch from source.
+        See `https://github.com/pytorch/pytorch#from-source <https://github.com/pytorch/pytorch#from-source>`_.
+
+    """
+
+    def __init__(self):
+        super(PyTorchConverter, self).__init__()
+
+        if not FLAG_PYTORCH_INSTALLED:
+            raise ImportError("""
+Module "pytorch" cannot be imported. Please check that follow command works correctly.
+    
+    python -c "import torch"
+
+""")
+
+        if not FLAG_ONNX_INSTALLED:
+            raise ImportError("""
+Module "onnx" cannot be imported. Please check that follow command works correctly.
+
+    python -c "import onnx"
+
+""")
+
+    def convert(self, model: "torch.nn.Module", dummy_inputs) -> Graph:
+        """convert(model)
+
+        Convert PyTorch computational graph into WebDNN IR.
+
+        .. admonition:: example
+
+            Convert PyTorch pre-trained AlexNet model.
+
+            .. code::
+
+                import torch, torchvision
+                from webdnn.frontend.pytorch import PyTorchConverter
+
+                model = torchvision.models.alexnet(pretrained=True)
+                dummy_input = torch.autograd.Variable(torch.randn(1, 3, 224, 224))
+
+                graph = PyTorchConverter().convert(model, dummy_input)
+
+        Returns:
+            (:class:`~webdnn.Graph`): WebDNN Graph
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proto_path = path.join(tmpdir, "model.proto")
+            torch.onnx.export(model, dummy_inputs, proto_path, verbose=False)
+            graph = ONNXConverter().convert(onnx.load(proto_path))
+
+        return graph

--- a/src/graph_transpiler/webdnn/frontend/tensorflow/converter.py
+++ b/src/graph_transpiler/webdnn/frontend/tensorflow/converter.py
@@ -28,18 +28,20 @@ except Exception as e:
 class TensorFlowConverter(Converter["tf.Operation"]):
     """TensorFlowConverter(batch_size=1)
 
-    Convert tf.Graph into WebDNN IR.
+    Converter for `TensorFlow <https://www.tensorflow.org/>`_
 
     Args:
-        session (:code:`tf.Session`): Session
-
+        session (:code:`tf.Session`): Session. As default, `tf.get_default_session()` is used.
     """
 
-    def __init__(self, session: "tf.Session", batch_size: int = 1):
+    def __init__(self, session: "tf.Session" = None, batch_size: int = 1):
         super(TensorFlowConverter, self).__init__()
 
         if not FLAG_TF_INSTALLED:
             raise ImportError("[TensorFlowConverter] Failed to import Tensorflow.")
+
+        if session is None:
+            session = tf.get_default_session()
 
         self.session = session
         self._batch_size = Placeholder(label=Axis.N.name, value=batch_size)
@@ -56,9 +58,14 @@ class TensorFlowConverter(Converter["tf.Operation"]):
             outputs (list of `tf.Tensor`): tensorflow output tensors
             order_hints: Order annotations which helps webdnn's optimizer.
 
-        .. admonition:: Example
+        .. admonition:: example
+
+            Convert TensorFlow model.
 
             .. code::
+
+                import tensorflow as tf
+                from webdnn.frontend.tensorflow import TensorFlowConverter
 
                 # y = x @ W + b
                 x = tf.placeholder(tf.float32, [None, 784])
@@ -66,7 +73,7 @@ class TensorFlowConverter(Converter["tf.Operation"]):
                 b = tf.Variable(tf.zeros([10]))
                 y = tf.nn.softmax(tf.matmul(x, W) + b)
 
-                webdnn_graph = TensorFlowConverter().convert([x], [y])
+                graph = TensorFlowConverter().convert([x], [y])
 
         Returns:
             (:class:`~webdnn.graph.graph.Graph`): WebDNN IR Graph

--- a/src/graph_transpiler/webdnn/graph/operators/elementwise.py
+++ b/src/graph_transpiler/webdnn/graph/operators/elementwise.py
@@ -75,10 +75,13 @@ class Elementwise(Operator, metaclass=ABCMeta):
 
                 if Placeholder.check_resolved(x.shape_dict[axis]):
                     if Placeholder.check_resolved(y_shape_dict[axis]):
-                        assert y_shape_dict[axis] == x.shape_dict[axis] or x.shape_dict[axis] == 1, \
-                            "All input variables of elementwise operator should be same shape: " \
-                            f"y.shape_dict[{axis}]={y_shape_dict[axis]}, " \
-                            f"x{i}.shape_dict[{axis}]={x.shape_dict[axis]}"
+                        assert y_shape_dict[axis] == x.shape_dict[axis] or x.shape_dict[axis] == 1, f"""
+[Elementwise] All input variables of elementwise operator should be same shape:
+    (y.shape) = {y_shape_dict[a] for a in y_axes}
+    (x{i}.shape) = {x.shape}
+    (y.shape[{axis}]) = {y_shape_dict[axis]}
+    (x{i}.shape[{axis}]) = {x.shape_dict[axis]}"""
+
                     else:
                         y_shape_dict[axis] = x.shape_dict[axis]
 

--- a/src/graph_transpiler/webdnn/graph/variable.py
+++ b/src/graph_transpiler/webdnn/graph/variable.py
@@ -362,6 +362,8 @@ class Variable(Node):
         """reshape(shape, order)
         Reshape into specified order and shape. This is alias of follow codes.
 
+        .. code::
+
             Reshape(None, in_order=v.order,
                           out_order=order,
                           out_shape=shape)(v)[0]
@@ -379,6 +381,8 @@ class Variable(Node):
     def expand_dims(self, axis: Axis, index: int) -> "Variable":
         """expand_dims(shape, axis, index)
         Insert new axis whose size is 1. This is alias of follow codes.
+
+        .. code::
 
             new_axes = list(v.order.axes)
             new_axes.insert(index, axis)
@@ -402,6 +406,8 @@ class Variable(Node):
     def squeeze(self, axis: Optional[Axis] = None) -> "Variable":
         """expand_dims(shape, axis, index)
         Remove axis whose size is 1. This is alias of follow codes.
+
+        .. code::
 
             new_axes = list(v.order.axes)
             new_axes.remove(axis)
@@ -428,7 +434,7 @@ class Variable(Node):
         """combine_axes(shape, axes, axis)
         Combine some axes into one axis.
 
-        Examples:
+        .. code::
 
             x = Variable([2, 3, 4, 5], OrderNHWC)
 
@@ -475,6 +481,8 @@ class Variable(Node):
     def reshape_like(self, other: "Variable") -> "Variable":
         """reshape(shape, order)
         Reshape into same order and shape as :code:`other`. This is alias of follow codes.
+
+        .. code::
 
             Reshape(None, in_order=v.order,
                           out_order=other.order,

--- a/test/runtime/frontend_test/onnx_test/README.md
+++ b/test/runtime/frontend_test/onnx_test/README.md
@@ -1,0 +1,7 @@
+# onnx_test
+
+Unittests for ONNXConverter
+
+Because ONNX is not DNN execution framework but DNN model declaration format, it cannot to compute expected result by ONNX itself.
+Therefore, we compute the result by numpy and use ONNX just for model definition.
+

--- a/test/runtime/frontend_test/onnx_test/defs_test/generator_test/constant_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/generator_test/constant_test.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model, make_tensor
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(value, description: str = ""):
+    y = make_tensor_value_info("y", value.shape)
+    operator = make_node("Constant", [""], ["y"], value=make_tensor("y_value", value))
+
+    model = make_model([operator], [], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Constant {description}",
+        graph=graph,
+        inputs={},
+        expected={graph.outputs[0]: value},
+    )
+
+
+def test():
+    template(value=np.random.rand(2, 3, 4, 5), description="")

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/abs_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/abs_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = abs(vx)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Abs", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Abs {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/add_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/add_test.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x0_shape, x1_shape, broadcast=0, axis=None, description: str = ""):
+    vx0 = np.random.rand(*x0_shape)
+    vx1 = np.random.rand(*x1_shape)
+    if axis is not None:
+        # onnx-style broadcast
+        vx1 = vx1[(None,) * axis + (...,) + (None,) * (vx0.ndim - vx1.ndim - axis)]
+
+    vy = vx0 + vx1
+
+    x0 = make_tensor_value_info("x0", x0_shape)
+    x1 = make_tensor_value_info("x1", x1_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {"broadcast": broadcast}
+    if axis is not None:
+        kwargs["axis"] = axis
+    operator = make_node("Add", ["x0", "x1"], ["y"], **kwargs)
+
+    model = make_model([operator], [x0, x1], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Add {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: vx0,
+            graph.inputs[1]: vx1
+        },
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 3, 4, 5])
+
+
+def test_broadcast1():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[1], broadcast=1)
+
+
+def test_broadcast2():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[5], broadcast=1)
+
+
+def test_broadcast3():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[4, 5], broadcast=1)
+
+
+def test_broadcast4():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[3, 4], broadcast=1, axis=1)
+
+
+def test_broadcast5():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2], broadcast=1, axis=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/div_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/div_test.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x0_shape, x1_shape, broadcast=0, axis=None, description: str = ""):
+    vx0 = np.random.rand(*x0_shape)
+    vx1 = np.random.rand(*x1_shape)
+    if axis is not None:
+        # onnx-style broadcast
+        vx1 = vx1[(None,) * axis + (...,) + (None,) * (vx0.ndim - vx1.ndim - axis)]
+
+    vy = vx0 / vx1
+
+    x0 = make_tensor_value_info("x0", x0_shape)
+    x1 = make_tensor_value_info("x1", x1_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {"broadcast": broadcast}
+    if axis is not None:
+        kwargs["axis"] = axis
+    operator = make_node("Div", ["x0", "x1"], ["y"], **kwargs)
+
+    model = make_model([operator], [x0, x1], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Div {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: vx0,
+            graph.inputs[1]: vx1
+        },
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 3, 4, 5])
+
+
+def test_broadcast1():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[1], broadcast=1)
+
+
+def test_broadcast2():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[5], broadcast=1)
+
+
+def test_broadcast3():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[4, 5], broadcast=1)
+
+
+def test_broadcast4():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[3, 4], broadcast=1, axis=1)
+
+
+def test_broadcast5():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2], broadcast=1, axis=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/elu_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/elu_test.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, alpha=1.0, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = vx.copy()
+    vy[vx < 0] = np.exp(vy[vx < 0]) - 1
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Elu", ["x"], ["y"], alpha=alpha)
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Elu {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])
+
+# TODO: Not supported yet
+# def test_alpha():
+#     template(x0_shape=[2, 3, 4, 5], alpha=0.3)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/exp_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/exp_test.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = np.exp(vx)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Exp", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Exp {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+        EPS=1e-2
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/gemm_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/gemm_test.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(M=5, K=6, N=7, c_shape=None, transA=False, transB=False, broadcast=False, alpha=1.0, beta=0.0,
+             description: str = ""):
+    if c_shape is None:
+        c_shape = [M, N]
+
+    va = np.random.rand(*((K, M) if transA else (M, K)))
+    vb = np.random.rand(*((N, K) if transB else (K, N)))
+    vc = np.random.rand(*c_shape)
+    vd = (va.T if transA else va) @ (vb.T if transB else vb) * alpha + vc * beta
+
+    kwargs = {
+        "broadcast": broadcast,
+        "transA": transA,
+        "transB": transB,
+        "alpha": alpha,
+        "beta": beta
+    }
+
+    a = make_tensor_value_info("a", va.shape)
+    b = make_tensor_value_info("b", vb.shape)
+    c = make_tensor_value_info("c", vc.shape)
+    d = make_tensor_value_info("d", vd.shape)
+
+    operator = make_node("Gemm", ["a", "b", "c"], ["d"], **kwargs)
+    model = make_model([operator], [a, b, c], [d])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Gemm {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: va,
+            graph.inputs[1]: vb,
+            graph.inputs[2]: vc
+        },
+        expected={graph.outputs[0]: vd},
+    )
+
+
+def test_NN():
+    template()
+
+
+def test_NT():
+    template(transB=True)
+
+
+def test_TN():
+    template(transA=True)
+
+
+def test_TT():
+    template(transA=True, transB=True)
+
+
+def test_alpha():
+    template(alpha=2.0)
+
+
+def test_beta():
+    template(beta=2.0)
+
+
+def test_broadcast():
+    template(M=5, K=6, N=7, broadcast=True, c_shape=[5, 1])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/leaky_relu_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/leaky_relu_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, alpha, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = np.maximum(vx, vx * alpha)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("LeakyRelu", ["x"], ["y"], alpha=alpha)
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] LeakyRelu {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5], alpha=0.5)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/log_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/log_test.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape)
+    vy = np.log(vx)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Log", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Log {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+        EPS=1e-2
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/mul_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/mul_test.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x0_shape, x1_shape, broadcast=0, axis=None, description: str = ""):
+    vx0 = np.random.rand(*x0_shape)
+    vx1 = np.random.rand(*x1_shape)
+    if axis is not None:
+        # onnx-style broadcast
+        vx1 = vx1[(None,) * axis + (...,) + (None,) * (vx0.ndim - vx1.ndim - axis)]
+
+    vy = vx0 * vx1
+
+    x0 = make_tensor_value_info("x0", x0_shape)
+    x1 = make_tensor_value_info("x1", x1_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {"broadcast": broadcast}
+    if axis is not None:
+        kwargs["axis"] = axis
+    operator = make_node("Mul", ["x0", "x1"], ["y"], **kwargs)
+
+    model = make_model([operator], [x0, x1], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Mul {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: vx0,
+            graph.inputs[1]: vx1
+        },
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 3, 4, 5])
+
+
+def test_broadcast1():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[1], broadcast=1)
+
+
+def test_broadcast2():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[5], broadcast=1)
+
+
+def test_broadcast3():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[4, 5], broadcast=1)
+
+
+def test_broadcast4():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[3, 4], broadcast=1, axis=1)
+
+
+def test_broadcast5():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2], broadcast=1, axis=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/neg_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/neg_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape)
+    vy = -vx
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Neg", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Neg {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/pow_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/pow_test.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x0_shape, x1_shape, description: str = ""):
+    vx0 = np.random.rand(*x0_shape)
+    vx1 = np.random.rand(*x1_shape)
+    vy = vx0 ** vx1
+
+    x0 = make_tensor_value_info("x0", vx0.shape)
+    x1 = make_tensor_value_info("x1", vx1.shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    operator = make_node("Pow", ["x0", "x1"], ["y"])
+
+    model = make_model([operator], [x0, x1], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Pow {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: vx0,
+            graph.inputs[1]: vx1
+        },
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 3, 4, 5])
+
+
+def test_implicit_broadcast():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 1, 4, 1])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/reciprocal_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/reciprocal_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape)
+    vy = 1 / vx
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Reciprocal", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Reciprocal {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/relu_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/relu_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = vx * (vx > 0)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Relu", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Relu {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/sigmoid_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/sigmoid_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = 1 / (1 + np.exp(-vx))
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Sigmoid", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Sigmoid {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/softmax_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/softmax_test.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, axis, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = np.exp(vx) / np.sum(np.exp(vx), axis=axis, keepdims=True)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Softmax", ["x"], ["y"], axis=axis)
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Softmax {description}",
+        graph=graph,
+        backend=["webgpu", "webgl", "webassembly"],
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5], axis=1)
+
+
+def test_most_inner_axis():
+    template(x_shape=[2, 3, 4, 5], axis=3)
+
+
+def test_most_outer_axis():
+    template(x_shape=[2, 3, 4, 5], axis=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/sub_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/sub_test.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x0_shape, x1_shape, broadcast=0, axis=None, description: str = ""):
+    vx0 = np.random.rand(*x0_shape) * 10
+    vx1 = np.random.rand(*x1_shape)
+    if axis is not None:
+        # onnx-style broadcast
+        vx1 = vx1[(None,) * axis + (...,) + (None,) * (vx0.ndim - vx1.ndim - axis)]
+
+    vy = vx0 - vx1
+
+    x0 = make_tensor_value_info("x0", x0_shape)
+    x1 = make_tensor_value_info("x1", x1_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {"broadcast": broadcast}
+    if axis is not None:
+        kwargs["axis"] = axis
+    operator = make_node("Sub", ["x0", "x1"], ["y"], **kwargs)
+
+    model = make_model([operator], [x0, x1], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Sub {description}",
+        graph=graph,
+        inputs={
+            graph.inputs[0]: vx0,
+            graph.inputs[1]: vx1
+        },
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2, 3, 4, 5])
+
+
+def test_broadcast1():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[1], broadcast=1)
+
+
+def test_broadcast2():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[5], broadcast=1)
+
+
+def test_broadcast3():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[4, 5], broadcast=1)
+
+
+def test_broadcast4():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[3, 4], broadcast=1, axis=1)
+
+
+def test_broadcast5():
+    template(x0_shape=[2, 3, 4, 5], x1_shape=[2], broadcast=1, axis=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/sum_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/sum_test.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, num_input=2, description: str = ""):
+    vxs = [np.random.rand(*x_shape) for _ in range(num_input)]
+    vy = np.zeros(x_shape)
+    for vx in vxs:
+        vy += vx
+
+    xs = [make_tensor_value_info(f"x{i}", vxs[i].shape) for i in range(num_input)]
+    y = make_tensor_value_info("y", vy.shape)
+
+    operator = make_node("Sum", [x.name for x in xs], ["y"])
+
+    model = make_model([operator], xs, [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Sum {description}",
+        graph=graph,
+        inputs={v: x for v, x in zip(graph.inputs, vxs)},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5], num_input=2)
+
+
+def test_add_3_tensors():
+    template(x_shape=[2, 3, 4, 5], num_input=3)

--- a/test/runtime/frontend_test/onnx_test/defs_test/math_test/tanh_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/math_test/tanh_test.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, description: str = ""):
+    vx = np.random.rand(*x_shape) - 0.5
+    vy = np.tanh(vx)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Tanh", ["x"], ["y"])
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Tanh {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5])

--- a/test/runtime/frontend_test/onnx_test/defs_test/nn_test/average_pool_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/nn_test/average_pool_test.py
@@ -1,0 +1,62 @@
+import chainer
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(N=2, H=5, W=5, C=7, KH=3, KW=3, SH=1, SW=1, PH=1, PW=1, DH=1, DW=1, description: str = ""):
+    if DH != 1 or DW != 1:
+        raise NotImplementedError
+
+    x_shape = [N, C, H, W]
+
+    vx = np.random.rand(*x_shape)
+    vy = chainer.functions.average_pooling_2d(vx, ksize=[KH, KW], stride=[SH, SW], pad=[PH, PW]).data
+
+    x = make_tensor_value_info("x", x_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {
+        "kernel_shape": [KH, KW],
+        "strides": [SH, SW],
+        "dilations": [DH, DW],
+        "pads": [PH, PH, PW, PW]
+    }
+    operator = make_node("AveragePool", ["x"], ["y"], **kwargs)
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] AveragePool {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template()
+
+
+def test_projection():
+    template(KH=1, KW=1, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_global_pool():
+    template(KH=5, KW=5, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_odd_k():
+    template(KH=3, KW=5)
+
+
+def test_odd_s():
+    template(SH=1, SW=2)
+
+
+def test_odd_p():
+    template(PH=0, PW=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/nn_test/conv_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/nn_test/conv_test.py
@@ -1,0 +1,89 @@
+import chainer
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(N=2, H=5, W=5, Cin=7, Cout=9, KH=3, KW=3, SH=1, SW=1, PH=1, PW=1, DH=1, DW=1, use_bias=False, description: str = ""):
+    x_shape = [N, Cin, H, W]
+    w_shape = [Cout, Cin, KH, KW]
+
+    vx = np.random.rand(*x_shape)
+    vw = np.random.rand(*w_shape)
+    vb = np.random.rand(Cout) if use_bias else None
+
+    if DH != 1 or DW != 1:
+        vy = chainer.functions.dilated_convolution_2d(vx, vw, b=vb, stride=[SH, SW], pad=[PH, PW], dilate=[DH, DW]).data
+    else:
+        vy = chainer.functions.convolution_2d(vx, vw, b=vb, stride=[SH, SW], pad=[PH, PW]).data
+
+    x = make_tensor_value_info("x", x_shape)
+    w = make_tensor_value_info("w", w_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {
+        "kernel_shape": [KH, KW],
+        "strides": [SH, SW],
+        "dilations": [DH, DW],
+        "pads": [PH, PH, PW, PW]
+    }
+    if use_bias:
+        b = make_tensor_value_info("b", vb.shape)
+        operator = make_node("Conv", ["x", "w", "b"], ["y"], **kwargs)
+        model = make_model([operator], [x, w, b], [y])
+
+    else:
+        operator = make_node("Conv", ["x", "w"], ["y"], **kwargs)
+        model = make_model([operator], [x, w], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    inputs = {
+        graph.inputs[0]: vx,
+        graph.inputs[1]: vw
+    }
+
+    if use_bias:
+        inputs[graph.inputs[2]] = vb
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Conv {description}",
+        graph=graph,
+        inputs=inputs,
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template()
+
+
+def test_projection():
+    template(KH=1, KW=1, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_global_conv():
+    template(KH=5, KW=5, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_odd_k():
+    template(KH=3, KW=5)
+
+
+def test_odd_s():
+    template(SH=1, SW=2)
+
+
+def test_odd_p():
+    template(PH=0, PW=0)
+
+
+def test_dilation():
+    template(DH=2, DW=2)
+
+
+def test_with_bias():
+    template(use_bias=True)

--- a/test/runtime/frontend_test/onnx_test/defs_test/nn_test/max_pool_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/nn_test/max_pool_test.py
@@ -1,0 +1,62 @@
+import chainer
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(N=2, H=5, W=5, C=7, KH=3, KW=3, SH=1, SW=1, PH=1, PW=1, DH=1, DW=1, description: str = ""):
+    if DH != 1 or DW != 1:
+        raise NotImplementedError
+
+    x_shape = [N, C, H, W]
+
+    vx = np.random.rand(*x_shape)
+    vy = chainer.functions.max_pooling_2d(vx, ksize=[KH, KW], stride=[SH, SW], pad=[PH, PW]).data
+
+    x = make_tensor_value_info("x", x_shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    kwargs = {
+        "kernel_shape": [KH, KW],
+        "strides": [SH, SW],
+        "dilations": [DH, DW],
+        "pads": [PH, PH, PW, PW]
+    }
+    operator = make_node("MaxPool", ["x"], ["y"], **kwargs)
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] MaxPool {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template()
+
+
+def test_projection():
+    template(KH=1, KW=1, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_global_pool():
+    template(KH=5, KW=5, SH=1, SW=1, PH=0, PW=0)
+
+
+def test_odd_k():
+    template(KH=3, KW=5)
+
+
+def test_odd_s():
+    template(SH=1, SW=2)
+
+
+def test_odd_p():
+    template(PH=0, PW=0)

--- a/test/runtime/frontend_test/onnx_test/defs_test/tensor_test/reshape_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/tensor_test/reshape_test.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, y_shape, description: str = ""):
+    vx = np.random.rand(*x_shape)
+    vy = np.reshape(vx, [x if y == 0 else y for x, y in zip(x_shape, y_shape)])
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+    operator = make_node("Reshape", ["x"], ["y"], shape=y_shape)
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    assert list(vy.shape) == list(graph.outputs[0].shape)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Reshape {description}",
+        graph=graph,
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5], y_shape=[4, 5, 3, 2])
+
+
+def test_change_dim():
+    template(x_shape=[2, 3, 4, 5], y_shape=[8, 5, 3])
+
+
+def test_wildcard():
+    template(x_shape=[2, 3, 4, 5], y_shape=[4, 5, -1, 2])
+
+
+def test_no_change():
+    template(x_shape=[2, 3, 4, 5], y_shape=[0, 0, 0, 5])
+
+
+def test_flatten():
+    template(x_shape=[2, 3, 4, 5], y_shape=[0, -1])

--- a/test/runtime/frontend_test/onnx_test/defs_test/tensor_test/transpose_test.py
+++ b/test/runtime/frontend_test/onnx_test/defs_test/tensor_test/transpose_test.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from test.runtime.frontend_test.onnx_test.util import make_node, make_tensor_value_info, make_model
+from test.util import wrap_template, generate_kernel_test_case
+from webdnn.frontend.onnx import ONNXConverter
+
+
+@wrap_template
+def template(x_shape, perm=None, description: str = ""):
+    vx = np.random.rand(*x_shape)
+    vy = np.transpose(vx, perm)
+
+    x = make_tensor_value_info("x", vx.shape)
+    y = make_tensor_value_info("y", vy.shape)
+
+    if perm is None:
+        operator = make_node("Transpose", ["x"], ["y"])
+    else:
+        operator = make_node("Transpose", ["x"], ["y"], perm=perm)
+
+    model = make_model([operator], [x], [y])
+
+    graph = ONNXConverter().convert(model)
+
+    assert list(vy.shape) == list(graph.outputs[0].shape)
+
+    generate_kernel_test_case(
+        description=f"[ONNX] Transpose {description}",
+        graph=graph,
+        backend=["webgpu", "webassembly", "webgl"],
+        inputs={graph.inputs[0]: vx},
+        expected={graph.outputs[0]: vy},
+    )
+
+
+def test():
+    template(x_shape=[2, 3, 4, 5], perm=[2, 0, 3, 1])
+
+
+def test_omit_perm():
+    template(x_shape=[2, 3, 4, 5], perm=None)

--- a/test/runtime/frontend_test/onnx_test/util.py
+++ b/test/runtime/frontend_test/onnx_test/util.py
@@ -1,0 +1,165 @@
+"""
+Some of this code is based on codes of ONNX project from follow URL.
+
+https://github.com/onnx/onnx/blob/23b88a1e0f3ac40bb8bf6d82a480eaab83622a8c/onnx/helper.py
+
+-------------------------------------------------------------------------------
+
+Open Neural Network Exchange
+
+Copyright (c) Facebook, Inc. and Microsoft Corporation.
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import numbers
+from typing import Sequence, Iterable
+
+import numpy as np
+from onnx import TensorProto, AttributeProto, NodeProto, ModelProto, GraphProto, ValueInfoProto
+
+from webdnn.frontend.onnx.type_hint import INodeProto, IAttributeProto, IModelProto, ITensorProto, DataType, IValueInfoProto
+
+
+def make_attribute(key: str, value) -> IAttributeProto:
+    attr = AttributeProto()
+    attr.name = key
+
+    is_iterable = isinstance(value, Iterable)
+    bytes_or_false = _to_bytes_or_false(value)
+    # First, singular cases
+
+    # float
+    if isinstance(value, float):
+        attr.f = value
+
+    # integer
+    elif isinstance(value, numbers.Integral):
+        attr.i = value
+
+    # string
+    elif bytes_or_false:
+        attr.s = bytes_or_false
+
+    elif isinstance(value, TensorProto):
+        attr.t.CopyFrom(value)
+
+    elif isinstance(value, GraphProto):
+        attr.g.CopyFrom(value)
+
+    # third, iterable cases
+    elif is_iterable:
+        byte_array = [_to_bytes_or_false(v) for v in value]
+        if all(isinstance(v, float) for v in value):
+            attr.floats.extend(value)
+
+        elif all(isinstance(v, numbers.Integral) for v in value):
+            # Turn np.int32/64 into Python built-in int.
+            attr.ints.extend(int(v) for v in value)
+
+        elif all(byte_array):
+            attr.strings.extend(byte_array)
+
+        elif all(isinstance(v, TensorProto) for v in value):
+            attr.tensors.extend(value)
+
+        elif all(isinstance(v, GraphProto) for v in value):
+            attr.graphs.extend(value)
+
+        else:
+            raise ValueError(
+                "You passed in an iterable attribute but I cannot figure out "
+                "its applicable type.")
+    else:
+        raise ValueError(
+            'Value "{}" is not valid attribute data type.'.format(value))
+
+    return attr
+
+
+def make_node(op_type: str, inputs: Sequence[str], outputs: Sequence[str], **kwargs) -> INodeProto:
+    node = NodeProto()
+    node.op_type = op_type
+    node.input.extend(inputs)
+    node.output.extend(outputs)
+    node.attribute.extend(make_attribute(key, value) for key, value in kwargs.items())
+    return node
+
+
+def make_model(nodes: Sequence[INodeProto],
+               inputs: Sequence[IValueInfoProto],
+               outputs: Sequence[IValueInfoProto],
+               initializer=None) -> IModelProto:
+    if initializer is None:
+        initializer = []
+    graph = GraphProto()
+    graph.node.extend(nodes)
+    graph.input.extend(inputs)
+    graph.output.extend(outputs)
+    graph.initializer.extend(initializer)
+
+    model = ModelProto()
+    model.graph.CopyFrom(graph)
+
+    return model
+
+
+def make_tensor(name: str, vals: np.ndarray) -> ITensorProto:
+    """
+    Make a TensorProto with specified arguments.  If raw is False, this
+    function will choose the corresponding proto field to store the
+    values based on data_type. If raw is True, use "raw_data" proto
+    field to store the values, and values should be of type bytes in
+    this case.
+    """
+    vals = vals.astype(np.float32)
+    
+    tensor = TensorProto()
+    tensor.data_type = DataType.FLOAT
+    tensor.name = name
+    tensor.raw_data = vals.tobytes()
+    tensor.dims.extend(vals.shape)
+    return tensor
+
+
+def make_tensor_value_info(name: str, shape: Sequence[int]) -> IValueInfoProto:
+    value_info_proto = ValueInfoProto()
+    value_info_proto.name = name
+
+    tensor_type_proto = value_info_proto.type.tensor_type
+    tensor_type_proto.elem_type = DataType.FLOAT
+
+    tensor_shape_proto = tensor_type_proto.shape.dim
+
+    for d in shape:
+        dim = tensor_shape_proto.add()
+        dim.dim_value = d
+
+    return value_info_proto
+
+
+def _to_bytes_or_false(val):
+    """
+    An internal graph to convert the input to a bytes or to False.
+    The criteria for conversion is as follows and should be python 2 and 3
+    compatible:
+    - If val is py2 str or py3 bytes: return bytes
+    - If val is py2 unicode or py3 str: return val.decode('ascii')
+    - Otherwise, return False
+    """
+
+    if isinstance(val, bytes):
+        return val
+
+    else:
+        try:
+            return val.encode('ascii')
+
+        except AttributeError:
+            return False


### PR DESCRIPTION
Support conversion from [Open Neural Network Exchange (ONNX)](https://onnx.ai) format.

Some framework supports to export model as ONNX format. Therefore also their model can be converted. I add `PyTorchConverter` through `ONNXConverter`.