### PR TITLE
Now add function loadScript, so that the fallback javascript can debug in.

### DIFF
--- a/src/descriptor_runner/tsconfig.json
+++ b/src/descriptor_runner/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "target": "es2016",
+        "target": "es2017",
         "strictNullChecks": true,
         "lib": [
             "es2017",

--- a/src/graph_transpiler/webdnn/__init__.py
+++ b/src/graph_transpiler/webdnn/__init__.py
@@ -1,7 +1,10 @@
 import pkg_resources
 
-__version__ = pkg_resources.require("webdnn")[0].version
-
+try:
+  __version__ = pkg_resources.require("webdnn")[0].version
+except:
+  __version__ = '1.x.x.git'
+  pass
 from webdnn import backend
 from webdnn import encoder
 from webdnn import frontend

--- a/src/graph_transpiler/webdnn/util/console.py
+++ b/src/graph_transpiler/webdnn/util/console.py
@@ -20,7 +20,10 @@ class Color:
 
 
 def colorize(text: str, color: int, bright: bool = False):
-    return f"{ESC}[{'1' if bright else '0'};3{color}m{text}{ESC}[0;39m"
+    if sys.platform == 'win32':
+      return text
+    else:
+      return f"{ESC}[{'1' if bright else '0'};3{color}m{text}{ESC}[0;39m"
 
 
 def warning(message: str, category: Optional[Type[Warning]] = Warning):


### PR DESCRIPTION
This is usefull to debgging new models.
I suggest not drop the fallback support.
Cause in some case, we need verify or debugging if our networks are converted valid or running valid.