### PR TITLE
support tf.pad with CONSTANT/REFLECT/SYMMETRY mode

### DIFF
--- a/src/graph_transpiler/webdnn/graph/operators/tile.py
+++ b/src/graph_transpiler/webdnn/graph/operators/tile.py
@@ -56,7 +56,7 @@ class Tile(Operator):
         x = self.inputs["x"]  # type: ConstantVariable
         y = self.outputs["y"]
 
-        new_y = ConstantVariable(np.tile(x.data, self.multiplier), x.order)
+        new_y = ConstantVariable(np.tile(x.data, [self.multiplier[a] for a in x.order.axes]), x.order)
         new_y.change_order(y.order)
         OptimizeRule.replace_variable(graph, y, new_y)
         self.remove_all()

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_array_ops_test/mirror_pad.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_array_ops_test/mirror_pad.py
@@ -5,9 +5,9 @@ from test.util import generate_kernel_test_case, wrap_template
 
 
 @wrap_template
-def template(x_shape, paddings, description: str = ""):
+def template(x_shape, paddings, mode, description: str = ""):
     x = tf.placeholder(np.float32, x_shape)
-    y = tf.pad(x, paddings)
+    y = tf.pad(x, paddings, mode=mode)
 
     vx = np.random.rand(*x_shape).astype(np.float32)
     with tf.Session() as sess:
@@ -17,16 +17,21 @@ def template(x_shape, paddings, description: str = ""):
 
     assert list(vy.shape) == list(y.shape)
     generate_kernel_test_case(
-        description=f"[TensorFlow] Pad {description}",
+        description=f"[TensorFlow] MirrorPad {description}",
         graph=graph,
+        backend=["webgpu", "webassembly", "webgl"],
         inputs={graph.inputs[0]: vx},
         expected={graph.outputs[0]: vy},
     )
 
 
-def test():
-    template(x_shape=[2, 4, 6, 8], paddings=[[0, 1], [2, 3], [4, 5], [6, 7]])
+def test_reflect():
+    template(x_shape=[2, 4, 6, 8], paddings=[[0, 1], [2, 3], [4, 5], [6, 7]], mode="REFLECT")
+
+
+def test_symmetric():
+    template(x_shape=[2, 4, 6, 8], paddings=[[0, 1], [2, 3], [4, 5], [6, 7]], mode="SYMMETRIC")
 
 
 def test_no_pad():
-    template(x_shape=[2, 4, 6, 8], paddings=[[0, 0], [0, 0], [0, 0], [0, 0]])
+    template(x_shape=[2, 4, 6, 8], paddings=[[0, 0], [0, 0], [0, 0], [0, 0]], mode="REFLECT")

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_array_ops_test/pad_v2_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_array_ops_test/pad_v2_test.py
@@ -5,9 +5,9 @@ from test.util import generate_kernel_test_case, wrap_template
 
 
 @wrap_template
-def template(x_shape, paddings, description: str = ""):
+def template(x_shape, paddings, constant_values, description: str = ""):
     x = tf.placeholder(np.float32, x_shape)
-    y = tf.pad(x, paddings)
+    y = tf.pad(x, paddings, constant_values=constant_values)
 
     vx = np.random.rand(*x_shape).astype(np.float32)
     with tf.Session() as sess:
@@ -17,7 +17,7 @@ def template(x_shape, paddings, description: str = ""):
 
     assert list(vy.shape) == list(y.shape)
     generate_kernel_test_case(
-        description=f"[TensorFlow] Pad {description}",
+        description=f"[TensorFlow] PadV2 {description}",
         graph=graph,
         inputs={graph.inputs[0]: vx},
         expected={graph.outputs[0]: vy},
@@ -25,8 +25,8 @@ def template(x_shape, paddings, description: str = ""):
 
 
 def test():
-    template(x_shape=[2, 4, 6, 8], paddings=[[0, 1], [2, 3], [4, 5], [6, 7]])
+    template(x_shape=[2, 4, 6, 8], paddings=[[0, 1], [2, 3], [4, 5], [6, 7]], constant_values=1)
 
 
 def test_no_pad():
-    template(x_shape=[2, 4, 6, 8], paddings=[[0, 0], [0, 0], [0, 0], [0, 0]])
+    template(x_shape=[2, 4, 6, 8], paddings=[[0, 0], [0, 0], [0, 0], [0, 0]], constant_values=1)


### PR DESCRIPTION
support `tf.pad` function in TensorFlow with follow modes:

- `mode = CONSTANT` (`tf::ops::Pad`, `tf::ops::PadV2`)
- `mode = REFLECT, SYMMETRY` (`tf::ops::MirrorPad`)