### PR TITLE
#694 fix cover_all mode setting in TF

### DIFF
--- a/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
+++ b/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
@@ -48,7 +48,7 @@ def avg_pool_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     x, padding = convolution_handler_preprocess(x, ksize=ksize, padding=tf_op.get_attr("padding"), dilation_rate=(1, 1),
                                                 data_format=data_format)
 
-    y, = AveragePooling2D(None, ksize=ksize, stride=stride, padding=padding)(x)
+    y, = AveragePooling2D(None, ksize=ksize, stride=stride, padding=padding, cover_all=False)(x)
     converter.set_variable(tf_op.outputs[0], y)
 
 
@@ -336,7 +336,7 @@ def max_pool_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     x, padding = convolution_handler_preprocess(x, ksize=ksize, padding=tf_op.get_attr("padding"), dilation_rate=(1, 1),
                                                 data_format=data_format)
 
-    y, = MaxPooling2D(None, ksize=ksize, stride=stride, padding=padding)(x)
+    y, = MaxPooling2D(None, ksize=ksize, stride=stride, padding=padding, cover_all=False)(x)
     converter.set_variable(tf_op.outputs[0], y)
 
 

--- a/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_test.py
@@ -58,3 +58,7 @@ def test_activation():
 
 def test_nobias():
     template(use_bias=False)
+
+
+def test_no_cover_all():
+    template(kernel_size=2, shape=(2, 2, 5), strides=2, padding="SAME")

--- a/test/runtime/frontend_test/keras_test/layers_test/pooling_test/average_pooling_2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/pooling_test/average_pooling_2d_test.py
@@ -5,12 +5,12 @@ from test.util import generate_kernel_test_case, wrap_template
 
 
 @wrap_template
-def template(pool_size=(3, 3), strides=(2, 2), padding="valid", data_format=None, description: str = ""):
-    x = keras.layers.Input((15, 17, 16))  # (height + pad * 2 - pool_size) % stride == 0 to avoid edge difference
+def template(pool_size=(3, 3), shape=(15, 17, 16), strides=(2, 2), padding="valid", data_format=None, description: str = ""):
+    x = keras.layers.Input(shape)
     y = keras.layers.AveragePooling2D(pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(x)
     model = keras.models.Model([x], [y])
 
-    vx = np.random.rand(2, 15, 17, 16)
+    vx = np.random.rand(2, *shape)
     vy = model.predict(vx, batch_size=2)
 
     graph = KerasConverter(batch_size=2, use_tensorflow_converter=False).convert(model)
@@ -39,6 +39,11 @@ def test_channels_first():
 def test_padding_valid():
     template(padding="valid")
 
+
 # FIXME: Not supported yet
 # def test_padding_same():
 #     template(padding="same")
+
+
+def test_no_cover_all():
+    template(pool_size=2, shape=(2, 2, 5), strides=2, padding="SAME")

--- a/test/runtime/frontend_test/keras_test/layers_test/pooling_test/max_pooling_2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/pooling_test/max_pooling_2d_test.py
@@ -5,12 +5,12 @@ from test.util import generate_kernel_test_case, wrap_template
 
 
 @wrap_template
-def template(pool_size=(3, 3), strides=2, padding="valid", data_format=None, description: str = ""):
-    x = keras.layers.Input((15, 17, 16))  # (height + pad * 2 - pool_size) % stride == 0 to avoid edge difference
+def template(pool_size=(3, 3), shape=(15, 17, 16), strides=2, padding="valid", data_format=None, description: str = ""):
+    x = keras.layers.Input(shape)
     y = keras.layers.MaxPooling2D(pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(x)
     model = keras.models.Model([x], [y])
 
-    vx = np.random.rand(2, 15, 17, 16)
+    vx = np.random.rand(2, *shape)
     vy = model.predict(vx, batch_size=2)
 
     graph = KerasConverter(batch_size=2, use_tensorflow_converter=False).convert(model)
@@ -46,3 +46,7 @@ def test_padding_same():
 
 def test_different_padding_size():
     template(padding="same", pool_size=(4, 4))  # padding = ((1, 2), (1, 2))
+
+
+def test_no_cover_all():
+    template(pool_size=2, shape=(2, 2, 5), strides=2, padding="SAME")

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/avg_pool_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/avg_pool_test.py
@@ -31,7 +31,6 @@ def test():
 # def test_pad_same():
 #     template(padding="SAME")
 
-
 def test_projection():
     template(ksize=[1, 1, 1, 1])
 
@@ -42,3 +41,7 @@ def test_global_pooling():
 
 def test_large_stride():
     template(x_shape=[2, 5, 5, 5], strides=[1, 2, 2, 1])
+
+
+def test_no_cover_all():
+    template(ksize=[1, 2, 2, 1], x_shape=[1, 2, 2, 5], strides=[1, 2, 2, 1], padding="SAME")

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/max_pool_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/max_pool_test.py
@@ -41,3 +41,7 @@ def test_global_pooling():
 
 def test_large_stride():
     template(x_shape=[2, 5, 5, 5], strides=[1, 2, 2, 1])
+
+
+def test_no_cover_all():
+    template(ksize=[1, 2, 2, 1], x_shape=[1, 2, 2, 5], strides=[1, 2, 2, 1], padding="SAME")


### PR DESCRIPTION
TensorFlow applies pooling operations as `cover_all = False` mode. However WebDNN converted these ops as `cover_all = True` mode.