### PR TITLE
fix output shape of deconvolution with odd size padding

### DIFF
--- a/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
+++ b/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
@@ -1,9 +1,7 @@
-from typing import List
-
 import tensorflow as tf
 
 from webdnn.frontend.tensorflow.converter import TensorFlowConverter
-from webdnn.frontend.tensorflow.util import unary_op_handler, convolution_handler_preprocess, check_data_format
+from webdnn.frontend.tensorflow.util import unary_op_handler, check_data_format, convert_odd_padding_to_concat, parse_padding
 from webdnn.graph.axis import Axis
 from webdnn.graph.operators.average_pooling_2d import AveragePooling2D
 from webdnn.graph.operators.clipped_relu import ClippedRelu
@@ -15,8 +13,8 @@ from webdnn.graph.operators.relu import Relu
 from webdnn.graph.operators.softmax import Softmax
 from webdnn.graph.operators.softplus import Softplus
 from webdnn.graph.operators.softsign import Softsign
-from webdnn.graph.order import OrderNHWC, Order
-from webdnn.graph.variables.constant_variable import ConstantVariable
+from webdnn.graph.order import Order
+from webdnn.util import console
 
 
 def padding_same(in_size: int, ksize: int, stride: int) -> int:
@@ -45,10 +43,19 @@ def avg_pool_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     assert stride[x.order.axes_dict[Axis.C]] == 1
     stride = (stride[x.order.axes_dict[Axis.H]], stride[x.order.axes_dict[Axis.W]])
 
-    x, padding = convolution_handler_preprocess(x, ksize=ksize, padding=tf_op.get_attr("padding"), dilation_rate=(1, 1),
-                                                data_format=data_format)
+    paddings = (
+        parse_padding(tf_op.get_attr("padding"), ksize[0], 1),
+        parse_padding(tf_op.get_attr("padding"), ksize[1], 1),
+    )
+    x, paddings = convert_odd_padding_to_concat(x, paddings=paddings)
 
-    y, = AveragePooling2D(None, ksize=ksize, stride=stride, padding=padding, cover_all=False)(x)
+    if any(p > 0 for p in paddings):
+        console.warning(
+            "[KerasConverter] keras.layers.AveragePooling computes average by dividing number of valid elements in window "
+            "(without padding element), but WebDNN divides it by the number of elements including padding element, so different "
+            "result will be generated on the edge.")
+
+    y, = AveragePooling2D(None, ksize=ksize, stride=stride, padding=paddings, cover_all=False)(x)
     converter.set_variable(tf_op.outputs[0], y)
 
 
@@ -125,10 +132,13 @@ def conv2_d_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     assert stride[x.order.axes_dict[Axis.C]] == 1
     stride = (stride[x.order.axes_dict[Axis.H]], stride[x.order.axes_dict[Axis.W]])
 
-    x, padding = convolution_handler_preprocess(x, ksize=ksize, padding=tf_op.get_attr("padding"), dilation_rate=(1, 1),
-                                                data_format=data_format)
+    paddings = (
+        parse_padding(tf_op.get_attr("padding"), ksize[0], 1),
+        parse_padding(tf_op.get_attr("padding"), ksize[1], 1),
+    )
+    x, paddings = convert_odd_padding_to_concat(x, paddings=paddings)
 
-    y, = Convolution2D(None, ksize=ksize, stride=stride, padding=padding)(x, w)
+    y, = Convolution2D(None, ksize=ksize, stride=stride, padding=paddings)(x, w)
     converter.set_variable(tf_op.outputs[0], y)
 
 
@@ -139,33 +149,45 @@ def conv2_d_backprop_filter_handler(converter: TensorFlowConverter, tf_op: "tf.O
 
 @TensorFlowConverter.register_handler("Conv2DBackpropInput")
 def conv2_d_backprop_input_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
-    input_sizes = converter.get_variable(tf_op.inputs[0])  # input_sizes is not needed
-    assert input_sizes.size == 4 and isinstance(input_sizes, ConstantVariable)
-    x_shape = input_sizes.data.flatten().astype(int).tolist()  # type: List[int]
+    # The first argument (input_sizes) is not needed
+    # input_sizes = converter.get_variable(tf_op.inputs[0])
 
     w = converter.get_variable(tf_op.inputs[1])  # HWNC
-    gy = converter.get_variable(tf_op.inputs[2])  # NHWC
-
-    assert tf_op.get_attr("data_format") == b"NHWC"
     w.order.unify(Order([Axis.KH, Axis.KW, Axis.N, Axis.C]))
-    gy.order.unify(OrderNHWC)
-    ksize_hw = (w.shape_dict[Axis.KH], w.shape_dict[Axis.KW])
 
-    stride_nhwc = tf_op.get_attr("strides")  # type: List[int]
-    assert stride_nhwc[0] == 1
-    assert stride_nhwc[3] == 1
-    stride_hw = stride_nhwc[1:3]
+    gy = converter.get_variable(tf_op.inputs[2])  # NHWC
+    data_format = tf_op.get_attr("data_format")
+    check_data_format(gy, data_format)
 
-    padding_name = tf_op.get_attr("padding")  # type: str
-    if padding_name == b"SAME":
-        padding = (padding_same(x_shape[gy.order.axes_dict[Axis.H]], ksize_hw[0], stride_hw[0]),
-                   padding_same(x_shape[gy.order.axes_dict[Axis.W]], ksize_hw[1], stride_hw[1]))
-    elif padding_name == b"VALID":
-        padding = (0, 0)
+    ksize = (w.shape_dict[Axis.KH], w.shape_dict[Axis.KW])
+
+    stride = tuple(tf_op.get_attr("strides"))  # type: Tuple[int,...]
+    assert stride[gy.order.axes_dict[Axis.N]] == 1
+    assert stride[gy.order.axes_dict[Axis.C]] == 1
+    stride = (stride[gy.order.axes_dict[Axis.H]], stride[gy.order.axes_dict[Axis.W]])
+
+    paddings = (
+        parse_padding(tf_op.get_attr("padding"), ksize[0], 1),
+        parse_padding(tf_op.get_attr("padding"), ksize[1], 1),
+    )
+
+    if any(p[0] != p[1] for p in paddings):
+        pad_col2im = tuple(p[0] if p[0] == p[1] else 0 for p in paddings)
+        pad_extra = tuple((0, 0) if p[0] == p[1] else p for p in paddings)
+        x, = Deconvolution2D(None, ksize=ksize, stride=stride, padding=pad_col2im)(gy, w)
+
+        if data_format == b"NCHW":
+            x = x[:, :, pad_extra[0][0]:-pad_extra[0][1], pad_extra[1][0]:-pad_extra[1][1]]
+
+        elif data_format == b"NHWC":
+            x = x[:, pad_extra[0][0]:-pad_extra[0][1], pad_extra[1][0]:-pad_extra[1][1], :]
+
+        else:
+            raise NotImplementedError(f"Unknown data format: {data_format}")
+
     else:
-        raise NotImplementedError(f"[TensorFlowConverter] Conv2D: padding '{padding_name}' is not supported yet.")
+        x, = Deconvolution2D(None, ksize=ksize, stride=stride, padding=tuple(p[0] for p in paddings))(gy, w)
 
-    x, = Deconvolution2D(None, ksize=ksize_hw, stride=stride_hw, padding=padding)(gy, w)
     converter.set_variable(tf_op.outputs[0], x)
 
 
@@ -333,10 +355,13 @@ def max_pool_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     assert stride[x.order.axes_dict[Axis.C]] == 1
     stride = (stride[x.order.axes_dict[Axis.H]], stride[x.order.axes_dict[Axis.W]])
 
-    x, padding = convolution_handler_preprocess(x, ksize=ksize, padding=tf_op.get_attr("padding"), dilation_rate=(1, 1),
-                                                data_format=data_format)
+    paddings = (
+        parse_padding(tf_op.get_attr("padding"), ksize[0], 1),
+        parse_padding(tf_op.get_attr("padding"), ksize[1], 1),
+    )
+    x, paddings = convert_odd_padding_to_concat(x, paddings=paddings, value=-1.0e10)
 
-    y, = MaxPooling2D(None, ksize=ksize, stride=stride, padding=padding, cover_all=False)(x)
+    y, = MaxPooling2D(None, ksize=ksize, stride=stride, padding=paddings, cover_all=False)(x)
     converter.set_variable(tf_op.outputs[0], y)
 
 

--- a/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
+++ b/src/graph_transpiler/webdnn/frontend/tensorflow/ops/gen_nn_ops.py
@@ -17,16 +17,6 @@ from webdnn.graph.order import Order
 from webdnn.util import console
 
 
-def padding_same(in_size: int, ksize: int, stride: int) -> int:
-    # https://www.tensorflow.org/api_guides/python/nn#Notes_on_SAME_Convolution_Padding
-    if in_size % stride == 0:
-        pad_total = max(ksize - stride, 0)
-    else:
-        pad_total = max(ksize - in_size % stride, 0)
-    pad_one_size = pad_total // 2 + pad_total % 2
-    return pad_one_size
-
-
 @TensorFlowConverter.register_handler("AvgPool")
 def avg_pool_handler(converter: TensorFlowConverter, tf_op: "tf.Operation"):
     x = converter.get_variable(tf_op.inputs[0])

--- a/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_test.py
@@ -32,16 +32,26 @@ def test():
     template()
 
 
+def test_padding_valid():
+    template(padding="valid")
+
+
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", shape=(5, 5, 3), kernel_size=3, strides=1)
+
+
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", shape=(4, 4, 3), kernel_size=2, strides=1)
+
+
 def test_kernel_size():
     template(kernel_size=2)
 
 
 def test_strides():
     template(strides=(2, 2))
-
-
-def test_padding():
-    template(padding="same")
 
 
 def test_data_format():

--- a/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_transpose_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/convolutional_test/conv2d_transpose_test.py
@@ -33,16 +33,26 @@ def test():
     template()
 
 
+def test_padding_valid():
+    template(padding="valid")
+
+
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", shape=(5, 5, 3), kernel_size=3, strides=1)
+
+
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", shape=(4, 4, 3), kernel_size=2, strides=1)
+
+
 def test_kernel_size():
     template(kernel_size=2)
 
 
 def test_strides():
     template(strides=(2, 2))
-
-
-def test_padding():
-    template(padding="same")
 
 
 def test_data_format():

--- a/test/runtime/frontend_test/keras_test/layers_test/pooling_test/average_pooling_2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/pooling_test/average_pooling_2d_test.py
@@ -28,6 +28,22 @@ def test():
     template()
 
 
+def test_padding_valid():
+    template(padding="valid")
+
+
+# FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
+# def test_padding_same_even_size():
+#     # pad: ((1,1), (1,1))
+#     template(padding="SAME", shape=(5, 5, 3), pool_size=3, strides=1)
+
+
+# FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
+# def test_padding_same_odd_size():
+#     # pad: ((1,0), (1,0))
+#     template(padding="SAME", shape=(4, 4, 3), pool_size=2, strides=1)
+
+
 def test_irregular_size():
     template(pool_size=(3, 4), strides=(2, 1))
 
@@ -35,15 +51,6 @@ def test_irregular_size():
 def test_channels_first():
     template(data_format="channels_first")
 
-
-def test_padding_valid():
-    template(padding="valid")
-
-
-# FIXME: Not supported yet
-# def test_padding_same():
-#     template(padding="same")
-
-
-def test_no_cover_all():
-    template(pool_size=2, shape=(2, 2, 5), strides=2, padding="SAME")
+# FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
+# def test_no_cover_all():
+#     template(pool_size=2, shape=(2, 2, 5), strides=2, padding="SAME")

--- a/test/runtime/frontend_test/keras_test/layers_test/pooling_test/max_pooling_2d_test.py
+++ b/test/runtime/frontend_test/keras_test/layers_test/pooling_test/max_pooling_2d_test.py
@@ -10,7 +10,7 @@ def template(pool_size=(3, 3), shape=(15, 17, 16), strides=2, padding="valid", d
     y = keras.layers.MaxPooling2D(pool_size=pool_size, strides=strides, padding=padding, data_format=data_format)(x)
     model = keras.models.Model([x], [y])
 
-    vx = np.random.rand(2, *shape)
+    vx = np.random.rand(2, *shape) - 0.5
     vy = model.predict(vx, batch_size=2)
 
     graph = KerasConverter(batch_size=2, use_tensorflow_converter=False).convert(model)
@@ -28,24 +28,26 @@ def test():
     template()
 
 
+def test_padding_valid():
+    template(padding="valid")
+
+
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", shape=(5, 5, 3), pool_size=3, strides=1)
+
+
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", shape=(4, 4, 3), pool_size=2, strides=1)
+
+
 def test_irregular_size():
     template(pool_size=(3, 4), strides=(2, 1))
 
 
 def test_channels_first():
     template(data_format="channels_first")
-
-
-def test_padding_valid():
-    template(padding="valid")
-
-
-def test_padding_same():
-    template(padding="same")
-
-
-def test_different_padding_size():
-    template(padding="same", pool_size=(4, 4))  # padding = ((1, 2), (1, 2))
 
 
 def test_no_cover_all():

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/avg_pool_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/avg_pool_test.py
@@ -15,6 +15,7 @@ def template(x_shape=[2, 3, 4, 5], ksize=[1, 3, 3, 1], strides=[1, 1, 1, 1], pad
         vy, = sess.run([y], {x: vx})
         graph = TensorFlowConverter(sess, batch_size=2).convert([x], [y])
 
+    assert list(vy.shape) == list(graph.outputs[0].shape), f"(vy.shape)={vy.shape}, (graph.outputs[0].shape)={graph.outputs[0].shape}"
     generate_kernel_test_case(
         description=f"[TensorFlow] AvgPool {description}",
         graph=graph,
@@ -27,21 +28,25 @@ def test():
     template()
 
 
+def test_padding_valid():
+    template(padding="VALID")
+
+
 # FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
-# def test_pad_same():
-#     template(padding="SAME")
-
-def test_projection():
-    template(ksize=[1, 1, 1, 1])
+# def test_padding_same_even_size():
+#     # pad: ((1,1), (1,1))
+#     template(padding="SAME", shape=(5, 5, 3), pool_size=3, strides=1)
 
 
-def test_global_pooling():
-    template(ksize=[1, 3, 4, 1])
+# FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
+# def test_padding_same_odd_size():
+#     # pad: ((1,0), (1,0))
+#     template(padding="SAME", shape=(4, 4, 3), pool_size=2, strides=1)
 
 
 def test_large_stride():
     template(x_shape=[2, 5, 5, 5], strides=[1, 2, 2, 1])
 
-
-def test_no_cover_all():
-    template(ksize=[1, 2, 2, 1], x_shape=[1, 2, 2, 5], strides=[1, 2, 2, 1], padding="SAME")
+# FIXME: TensorFlow's average pooling operation ignores padding value. Therefore result is different from WebDNN's result.
+# def test_no_cover_all():
+#     template(ksize=[1, 2, 2, 1], x_shape=[1, 2, 2, 5], strides=[1, 2, 2, 1], padding="SAME")

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/conv_2d_backprop_input_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/conv_2d_backprop_input_test.py
@@ -22,6 +22,7 @@ def template(N=2, Hin=5, Hout=3, Win=5, Wout=3, Cin=7, Cout=9, KH=3, KW=3, strid
         vx, = sess.run([x], {w: vw, gy: vgy})
         graph = TensorFlowConverter(sess, batch_size=2).convert([w, gy], [x])
 
+    assert list(vx.shape) == list(graph.outputs[0].shape), f"(vx.shape)={vx.shape}, (graph.outputs[0].shape)={graph.outputs[0].shape}"
     generate_kernel_test_case(
         description=f"[TensorFlow] Conv2DBackPropInput {description}",
         graph=graph,
@@ -38,16 +39,22 @@ def test():
     template()
 
 
-def test_pad_same():
-    template(padding="SAME", Hout=5, Wout=5)
+def test_padding_valid():
+    template(padding="VALID")
+
+
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", Hin=5, Win=5, Hout=5, Wout=5, KH=3, KW=3, strides=[1, 1, 1, 1])
+
+
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", Hin=4, Win=4, Hout=4, Wout=4, KH=2, KW=2, strides=[1, 1, 1, 1])
 
 
 def test_projection():
     template(KH=1, KW=1, Hout=5, Wout=5)
-
-
-def test_global_pooling():
-    template(KH=5, KW=5, Hout=1, Wout=1)
 
 
 def test_large_stride():

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/conv_2d_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/conv_2d_test.py
@@ -20,6 +20,7 @@ def template(N=2, H=5, W=5, Cin=7, Cout=9, KH=3, KW=3, strides=[1, 1, 1, 1], pad
         vy, = sess.run([y], {x: vx, w: vw})
         graph = TensorFlowConverter(sess, batch_size=2).convert([x, w], [y])
 
+    assert list(vy.shape) == list(graph.outputs[0].shape), f"(vy.shape)={vy.shape}, (graph.outputs[0].shape)={graph.outputs[0].shape}"
     generate_kernel_test_case(
         description=f"[TensorFlow] Conv2D {description}",
         graph=graph,
@@ -35,16 +36,22 @@ def test():
     template()
 
 
-def test_pad_same():
-    template(padding="SAME")
+def test_padding_valid():
+    template(padding="VALID")
+
+
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", H=5, W=5, KH=3, KW=3, strides=[1, 1, 1, 1])
+
+
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", H=4, W=4, KH=2, KW=2, strides=[1, 1, 1, 1])
 
 
 def test_projection():
     template(KH=1, KW=1)
-
-
-def test_global_pooling():
-    template(KH=5, KW=5)
 
 
 def test_large_stride():

--- a/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/max_pool_test.py
+++ b/test/runtime/frontend_test/tensorflow_test/ops_test/gen_nn_ops_test/max_pool_test.py
@@ -15,6 +15,7 @@ def template(x_shape=[2, 3, 4, 5], ksize=[1, 3, 3, 1], strides=[1, 1, 1, 1], pad
         vy, = sess.run([y], {x: vx})
         graph = TensorFlowConverter(sess, batch_size=2).convert([x], [y])
 
+    assert list(vy.shape) == list(graph.outputs[0].shape), f"(vy.shape)={vy.shape}, (graph.outputs[0].shape)={graph.outputs[0].shape}"
     generate_kernel_test_case(
         description=f"[TensorFlow] MaxPool {description}",
         graph=graph,
@@ -27,16 +28,18 @@ def test():
     template()
 
 
-def test_pad_valid():
+def test_padding_valid():
     template(padding="VALID")
 
 
-def test_projection():
-    template(ksize=[1, 1, 1, 1])
+def test_padding_same_even_size():
+    # pad: ((1,1), (1,1))
+    template(padding="SAME", x_shape=[2, 5, 5, 3], ksize=[1, 3, 3, 1], strides=[1, 1, 1, 1])
 
 
-def test_global_pooling():
-    template(ksize=[1, 3, 4, 1])
+def test_padding_same_odd_size():
+    # pad: ((1,0), (1,0))
+    template(padding="SAME", x_shape=[2, 4, 4, 3], ksize=[1, 2, 2, 1], strides=[1, 1, 1, 1])
 
 
 def test_large_stride():


### PR DESCRIPTION
```python
# x, w: tf.Tensor

x.shape=[batch_size, 4, 4, channel_in]
w.shape=[2, 2, channel_in, channel_out]
y_shape=[batch_size, 4, 4, channel_out]

y = tf.nn.conv2d_transpose(x, w, y_shape, strides=[1, 1, 1, 1], padding=b"SAME")

graph = TensorFlowConverter().convert([x], [y])
```

Previously,  TF tensor `y` was converted as WebDNN variable with wrong shape as `(batch_size, 3, 3, channel_out)`,  because padding size was converted as `(1, 1)`. The correct size is `(0, 1)`.