### PR TITLE
BGR semantic fix in getImageArrayFromImageData.

### DIFF
--- a/src/descriptor_runner/image/image_array.ts
+++ b/src/descriptor_runner/image/image_array.ts
@@ -117,15 +117,15 @@ export function getImageArrayFromImageData(imageData: ImageData,
 
         case Color.BGR:
             array = new type(width * height * 3);
-            [biasB, biasG, biasR] = bias_n;
-            [scaleB, scaleG, scaleR] = scale_n;
+            [biasR, biasG, biasB] = bias_n;
+            [scaleR, scaleG, scaleB] = scale_n;
             switch (order) {
                 case Order.HWC:
                     for (let h = 0; h < height; h++) {
                         for (let w = 0; w < width; w++) {
-                            array[(h * width + w) * 3 + 0] = (data[(h * width + w) * 4 + 2] - biasR) / scaleR;
+                            array[(h * width + w) * 3 + 0] = (data[(h * width + w) * 4 + 2] - biasB) / scaleB;
                             array[(h * width + w) * 3 + 1] = (data[(h * width + w) * 4 + 1] - biasG) / scaleG;
-                            array[(h * width + w) * 3 + 2] = (data[(h * width + w) * 4 + 0] - biasB) / scaleB;
+                            array[(h * width + w) * 3 + 2] = (data[(h * width + w) * 4 + 0] - biasR) / scaleR;
                         }
                     }
                     break;
@@ -133,9 +133,9 @@ export function getImageArrayFromImageData(imageData: ImageData,
                 case Order.CHW:
                     for (let h = 0; h < height; h++) {
                         for (let w = 0; w < width; w++) {
-                            array[(0 * height + h) * width + w] = (data[(h * width + w) * 4 + 2] - biasR) / scaleR;
+                            array[(0 * height + h) * width + w] = (data[(h * width + w) * 4 + 2] - biasB) / scaleB;
                             array[(1 * height + h) * width + w] = (data[(h * width + w) * 4 + 1] - biasG) / scaleG;
-                            array[(2 * height + h) * width + w] = (data[(h * width + w) * 4 + 0] - biasB) / scaleB;
+                            array[(2 * height + h) * width + w] = (data[(h * width + w) * 4 + 0] - biasR) / scaleR;
                         }
                     }
                     break;


### PR DESCRIPTION
Hi, 
I am opening this pull request because I think I may have found a semantic problem in the naming of the variables biasB, biasR, scaleB, scaleR in the function getImageArrayFromImageData which may be a little confusing. In particular these variables should have an inverted meaning in the case of Color.BGR (line 118), meaning biasB is indeed biasR and viceversa, and scaleB is indeed scaleR and viceversa.
As I understood from the code of image_array.ts, the image contained in "data" is assumed to be expressed in RGBA order. Bias is subtracted from this data structure which is in RGBA, then the resulting channel values are inverted to the BGR order.
I am assuming this function expects bias (and scale) options expressed in the RGB order because the source image is expressed in RGBA and because of what is written in the documentation:
> this method subtracts this value from **original** pixel value.

https://mil-tokyo.github.io/webdnn/docs/api_reference/descriptor-runner/modules/webdnn_image.html

Please note that this commit does not change the logic of the function but just its semantics.

Thanks,

Giovanni