### PR TITLE
#816: Fix weight packing procedure in WebGL backend.

### DIFF
--- a/src/graph_transpiler/webdnn/backend/webgl/allocator.py
+++ b/src/graph_transpiler/webdnn/backend/webgl/allocator.py
@@ -30,10 +30,8 @@ def _align(offset: int, unit: int = 1):
 
 
 class WebGLAllocation(Allocation):
-    def __init__(self, width: IntLike, height: IntLike, channel_mode: ChannelModeEnum, begin: int = _T_UNKNOWN, end: int = _T_UNKNOWN,
-                 name: str = None):
-        super(WebGLAllocation, self).__init__(size=width * height * ChannelMode.elements_per_pixel(channel_mode),
-                                              offset=-1, begin=begin, end=end, name=name)
+    def __init__(self, size: IntLike, width: IntLike, height: IntLike, channel_mode: ChannelModeEnum, begin: int = _T_UNKNOWN, end: int = _T_UNKNOWN, name: str = None):
+        super(WebGLAllocation, self).__init__(size=size, offset=-1, begin=begin, end=end, name=name)
         self.width = width
         self.height = height
         self.channel_mode = channel_mode
@@ -129,22 +127,21 @@ def _get_allocations(graph: Graph, operators: Sequence[Operator], variables: Seq
         # Constant variable cannot be released
         height, width = TextureShape.get(v)
         width = (width + ChannelMode.elements_per_pixel(v) - 1) // ChannelMode.elements_per_pixel(v)
-        allocations[v] = WebGLAllocation(width=width, height=height, channel_mode=ChannelMode.get(v), begin=0, end=T_LAST, name=v.name)
+        allocations[v] = WebGLAllocation(size=v.size, width=width, height=height, channel_mode=ChannelMode.get(v), begin=0, end=T_LAST, name=v.name)
         allocated.add(v)
 
     for v in graph.inputs:
         # Input variable cannot be released
         height, width = TextureShape.get(v)
         width = (width + ChannelMode.elements_per_pixel(v) - 1) // ChannelMode.elements_per_pixel(v)
-        allocations[v] = WebGLAllocation(width=width, height=height, channel_mode=ChannelMode.get(v), begin=0, end=T_LAST, name=v.name)
+        allocations[v] = WebGLAllocation(size=v.size, width=width, height=height, channel_mode=ChannelMode.get(v), begin=0, end=T_LAST, name=v.name)
         allocated.add(v)
 
     for v in graph.outputs:
         # Output variable cannot be released, but it's not needed to be allocated from the begin
         height, width = TextureShape.get(v)
         width = (width + ChannelMode.elements_per_pixel(v) - 1) // ChannelMode.elements_per_pixel(v)
-        allocations[v] = WebGLAllocation(width=width, height=height, channel_mode=ChannelMode.get(v), begin=_T_UNKNOWN, end=T_LAST,
-                                         name=v.name)
+        allocations[v] = WebGLAllocation(size=v.size, width=width, height=height, channel_mode=ChannelMode.get(v), begin=_T_UNKNOWN, end=T_LAST, name=v.name)
         allocated.add(v)
 
     for t, op in enumerate(operators):
@@ -158,8 +155,7 @@ def _get_allocations(graph: Graph, operators: Sequence[Operator], variables: Seq
                 # Create new allocation object
                 height, width = TextureShape.get(v)
                 width = (width + ChannelMode.elements_per_pixel(v) - 1) // ChannelMode.elements_per_pixel(v)
-                allocations[v] = WebGLAllocation(width=width, height=height, channel_mode=ChannelMode.get(v), begin=t, end=_T_UNKNOWN,
-                                                 name=v.name)
+                allocations[v] = WebGLAllocation(size=v.size, width=width, height=height, channel_mode=ChannelMode.get(v), begin=t, end=_T_UNKNOWN, name=v.name)
                 retain_count[v] = len(v.input_to)
                 allocated.add(v)
 
@@ -168,8 +164,7 @@ def _get_allocations(graph: Graph, operators: Sequence[Operator], variables: Seq
                 # Allocate
                 height, width = TextureShape.get(v)
                 width = (width + ChannelMode.elements_per_pixel(v) - 1) // ChannelMode.elements_per_pixel(v)
-                allocations[v] = WebGLAllocation(width=width, height=height, channel_mode=ChannelMode.get(v), begin=t, end=_T_UNKNOWN,
-                                                 name=v.name)
+                allocations[v] = WebGLAllocation(size=v.size, width=width, height=height, channel_mode=ChannelMode.get(v), begin=t, end=_T_UNKNOWN, name=v.name)
                 retain_count[v] = len(v.input_to)
                 allocated.add(v)
 

--- a/src/graph_transpiler/webdnn/encoder/constant_encoder_eightbit.py
+++ b/src/graph_transpiler/webdnn/encoder/constant_encoder_eightbit.py
@@ -59,7 +59,14 @@ class ConstantEncoderEightbit(ConstantEncoder):
     def encode(self, memory_layout: MemoryLayout) -> bytes:
         all_code = b""
         for alloc in memory_layout.allocations.values():
-            if alloc.offset >= memory_layout.data.size:
+            # TODO
+            # This if-statement checks whether this allocation has the initial values.
+            #
+            # We should improve this as follows:
+            #   1. Instead of concatenating all initial values, separate them and store it in each allocation instance.
+            #   2. When generating graph descriptor and related assets, concatenate them.
+            #
+            if alloc.offset < 0 or alloc.offset >= memory_layout.data.size:
                 continue
 
             single_data = memory_layout.data[alloc.offset:alloc.offset + alloc.size]


### PR DESCRIPTION
In WebGL backend, allocated buffer (texture) size and initial value's size are different. This patch fixes `WebGLAllocation.size` implementation, which was implemented as texture's size. From now, `WebGLAllocation.size` means required buffer size (= initial value's size) which is same semantics as original `Allocation.size` implementation.