### PR TITLE
fix: use TextDecoder for proper UTF-8 string parsing

### DIFF
--- a/src/descriptor_runner/core/tensorLoaderImpl.ts
+++ b/src/descriptor_runner/core/tensorLoaderImpl.ts
@@ -166,9 +166,9 @@ export class TensorLoaderImpl implements TensorLoader {
     byteOffset: number,
     byteLength: number
   ): string {
-    const view = new Uint8Array(buf, byteOffset, byteLength);
-    // TODO: support UTF-8
-    return String.fromCharCode(...Array.from(view));
+    // Use TextDecoder for proper UTF-8 support instead of String.fromCharCode
+    const bytes = new Uint8Array(buf, byteOffset, byteLength);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   }
 
   private parseTensorBody(


### PR DESCRIPTION
Replace the broken String.fromCharCode approach with TextDecoder('utf-8') for correct UTF-8 character decoding.

The old code only handled ASCII characters correctly. Multi-byte UTF-8 characters (e.g., non-Latin scripts, emojis) would be corrupted. Using TextDecoder with 'utf-8' encoding and fatal: true ensures proper UTF-8 string parsing with proper error handling.