### PR TITLE
Fix #971: Replace String.fromCharCode with TextDecoder for UTF-8 string parsing

### DIFF
--- a/src/descriptor_runner/core/tensorLoaderImpl.ts
+++ b/src/descriptor_runner/core/tensorLoaderImpl.ts
@@ -167,8 +167,7 @@ export class TensorLoaderImpl implements TensorLoader {
     byteLength: number
   ): string {
     const view = new Uint8Array(buf, byteOffset, byteLength);
-    // TODO: support UTF-8
-    return String.fromCharCode(...Array.from(view));
+    return new TextDecoder('utf-8').decode(view);
   }
 
   private parseTensorBody(

--- a/src/descriptor_runner/operators/operatorUtil.ts
+++ b/src/descriptor_runner/operators/operatorUtil.ts
@@ -125,12 +125,11 @@ export function getAttrString(
   if (!attr) {
     return defaultValue;
   }
-  // Only ASCII chars are considered
   const v = attr.s;
   if (v == null) {
     throw new Error(`Attribute ${name} is not string`);
   }
-  return String.fromCharCode(...Array.from(v));
+  return new TextDecoder('utf-8').decode(new Uint8Array(v));
 }
 
 export function arraySum(vec: ArrayLike<number>): number {


### PR DESCRIPTION
Fixes #971. Replaces String.fromCharCode with TextDecoder('utf-8').decode() for proper UTF-8 string parsing in two locations:

- `src/descriptor_runner/core/tensorLoaderImpl.ts`: `parseString()` method
- `src/descriptor_runner/operators/operatorUtil.ts`: `getAttrString()` function

String.fromCharCode only handles ASCII/Latin-1 characters correctly, causing mojibake for multi-byte UTF-8 sequences. TextDecoder correctly handles full UTF-8.